### PR TITLE
fix: remove blue left border accent on expanded nodes

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -591,17 +591,6 @@ body {
     border-radius: var(--burnish-radius-md, 4px);
     box-shadow: var(--burnish-shadow-sm);
 }
-.burnish-node[data-collapsed="false"]::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 3px;
-    background: var(--burnish-accent, #4f6df5);
-    z-index: 1;
-    border-radius: var(--burnish-radius-md, 4px) 0 0 var(--burnish-radius-md, 4px);
-}
 .burnish-node + .burnish-node {
     margin-top: var(--burnish-space-sm, 8px);
 }


### PR DESCRIPTION
Closes #33

## Summary
- Removed the `::before` pseudo-element on `.burnish-node[data-collapsed="false"]` that drew a 3px blue left accent bar on all expanded nodes
- Expanded nodes now have the same uniform border as collapsed nodes

## Changes
- `apps/demo/public/style.css` — Deleted the 11-line `.burnish-node[data-collapsed="false"]::before` rule block

## Test Plan
- [x] `pnpm build` passes
- [ ] `pnpm dev` starts successfully
- [ ] Expanded nodes no longer have a blue left border accent
- [ ] Collapsed nodes still display correctly (no visual regression)

---
*Created by autonomous agent workflow.*