### PR TITLE
feat(demo): auto-title sessions via LLM after first exchange

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -991,6 +991,27 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateBreadcrumb();
                 renderSessionList();
                 saveState();
+
+                // Auto-title: after first node completes, request an LLM-generated title
+                if (session.nodes.length === 1) {
+                    fetch('/api/title', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            prompt: node.promptDisplay,
+                            response: (trimmed || '').slice(0, 500),
+                        }),
+                    })
+                        .then(r => r.json())
+                        .then(data => {
+                            if (data.title) {
+                                session.title = data.title;
+                                renderSessionList();
+                                saveState();
+                            }
+                        })
+                        .catch(() => { /* keep truncated title as fallback */ });
+                }
             },
             // onError
             (error) => {

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -96,6 +96,18 @@ app.delete('/api/servers/:name', async (c) => {
     }
 });
 
+app.post('/api/title', async (c) => {
+    const { prompt, response } = await c.req.json<{ prompt: string; response: string }>();
+    try {
+        const title = await llm.generateTitle(prompt, response);
+        return c.json({ title });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        console.warn('[burnish] Title generation failed:', msg);
+        return c.json({ error: msg }, 500);
+    }
+});
+
 // Lookup result cache — avoids redundant LLM calls for identical prompts
 const lookupCache = new Map<string, { results: unknown[]; timestamp: number }>();
 const LOOKUP_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes

--- a/apps/demo/server/llm.ts
+++ b/apps/demo/server/llm.ts
@@ -413,6 +413,83 @@ async function* streamResponseApi(
 }
 
 // ═══════════════════════════════════════════════════════════════
+// Title Generation — lightweight LLM call to auto-title sessions
+// ═══════════════════════════════════════════════════════════════
+
+const TITLE_SYSTEM_PROMPT =
+    'Generate a concise 3-6 word title that describes the user\'s request. ' +
+    'Return ONLY the title text, no quotes, no punctuation at the end, no explanation.';
+
+/**
+ * Generate a short descriptive title for a session based on the first exchange.
+ * Uses haiku for speed and cost efficiency.
+ */
+export async function generateTitle(prompt: string, response: string): Promise<string> {
+    const truncatedResponse = response.slice(0, 500);
+    const userMessage = `User prompt: ${prompt}\n\nAssistant response (truncated): ${truncatedResponse}`;
+
+    if (backend === 'cli') {
+        return generateTitleCli(userMessage);
+    } else {
+        return generateTitleApi(userMessage);
+    }
+}
+
+async function generateTitleApi(userMessage: string): Promise<string> {
+    if (!client) throw new Error('LLM not configured');
+
+    const result = await client.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 30,
+        system: TITLE_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userMessage }],
+    });
+
+    const text = result.content
+        .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+        .map(b => b.text)
+        .join('');
+    return text.trim();
+}
+
+async function generateTitleCli(userMessage: string): Promise<string> {
+    const claudeCmd = process.platform === 'win32' ? 'claude.cmd' : 'claude';
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+
+    const fullPrompt = `${TITLE_SYSTEM_PROMPT}\n\n${userMessage}`;
+
+    return new Promise<string>((resolve, reject) => {
+        const proc = spawn(claudeCmd, [
+            '--print',
+            '--model', 'haiku',
+            '--tools', '',
+            '--setting-sources', 'user',
+        ], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+            env,
+            shell: process.platform === 'win32',
+        });
+
+        proc.stdin.write(fullPrompt);
+        proc.stdin.end();
+
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+        proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+        proc.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`claude exited with code ${code}: ${stderr}`));
+            } else {
+                resolve(stdout.trim());
+            }
+        });
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════
 // Lightweight Lookup — minimal prompt, no tools, text-in/text-out
 // ═══════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Closes #1

## Summary
- Add LLM-powered auto-titling for sessions — after the first exchange completes, a lightweight Haiku call generates a 3-6 word descriptive title replacing the truncated prompt placeholder
- Add `POST /api/title` endpoint using Haiku (API backend) or `claude --model haiku` (CLI backend) for fast, cheap title generation
- Include prompt caching and system prompt compression optimizations from prior commits

## Changes
- **`apps/demo/server/llm.ts`** — Added `generateTitle()` function with API and CLI backend support (haiku, max_tokens=30)
- **`apps/demo/server/index.ts`** — Added `POST /api/title` route accepting `{ prompt, response }` and returning `{ title }`
- **`apps/demo/public/app.js`** — Non-blocking title fetch in `onDone` callback for first node; updates session title, re-renders list, saves state
- **`apps/demo/public/style.css`** — Removed blue left border accent on expanded nodes
- **`apps/demo/server/prompt-template.ts`** — Compressed system prompt (~60% smaller)

## Test Plan
- [x] `pnpm build` passes
- [ ] `pnpm dev` starts successfully
- [ ] Submit prompt in new session → truncated title appears immediately, then updates to LLM-generated title after response completes
- [ ] Title persists after page refresh (localStorage)
- [ ] Second session preserves first session's title
- [ ] Graceful degradation if title generation fails (keeps truncated title)

---
*Created by autonomous agent workflow.*