### PR TITLE
feat(demo): add dashboard mode toggle

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -36,6 +36,7 @@ let cancelGeneration = 0;
 let fastMode = localStorage.getItem('burnish:fastMode') === 'true';
 let searchQuery = '';
 let searchDebounceTimer = null;
+let dashboardMode = localStorage.getItem('burnish:dashboardMode') === 'true';
 
 // Multi-session state
 let sessions = [];
@@ -1104,6 +1105,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             localStorage.setItem('burnish:fastMode', String(fastMode));
         });
     }
+
+    // ── Dashboard mode toggle ──
+    if (dashboardMode) {
+        document.body.dataset.dashboard = 'true';
+        document.getElementById('btn-dashboard-toggle')?.classList.add('active');
+    }
+
+    document.getElementById('btn-dashboard-toggle')?.addEventListener('click', () => {
+        dashboardMode = !dashboardMode;
+        localStorage.setItem('burnish:dashboardMode', String(dashboardMode));
+        document.body.dataset.dashboard = dashboardMode ? 'true' : 'false';
+        document.getElementById('btn-dashboard-toggle')?.classList.toggle('active', dashboardMode);
+    });
 
     // ── Session panel events ──
     document.getElementById('btn-new-session')?.addEventListener('click', () => createSession());

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -77,6 +77,14 @@
             <span class="burnish-breadcrumb" id="breadcrumb">Dashboard</span>
         </div>
         <div class="burnish-header-right">
+            <button id="btn-dashboard-toggle" class="burnish-header-btn" title="Dashboard mode">
+                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <rect x="1" y="1" width="7" height="7" rx="1"/>
+                    <rect x="10" y="1" width="7" height="7" rx="1"/>
+                    <rect x="1" y="10" width="7" height="7" rx="1"/>
+                    <rect x="10" y="10" width="7" height="7" rx="1"/>
+                </svg>
+            </button>
             <div id="fast-toggle" class="burnish-fast-toggle" title="Use faster model (Haiku)">
                 <span>Fast</span>
                 <div class="burnish-fast-toggle-switch"></div>

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1029,6 +1029,31 @@ body {
     flex-shrink: 0;
 }
 
+/* ── Dashboard Mode ── */
+[data-dashboard="true"] .burnish-session-panel { display: none; }
+[data-dashboard="true"] .burnish-prompt-bar { display: none; }
+[data-dashboard="true"] .burnish-content { margin-left: 0; }
+[data-dashboard="true"] .burnish-node-header { display: none; }
+[data-dashboard="true"] .burnish-node-prompt-bubble { display: none; }
+[data-dashboard="true"] .burnish-node[data-collapsed="true"] .burnish-node-content { display: flex; }
+[data-dashboard="true"] .burnish-node-content {
+    border: none;
+    border-radius: 0;
+    padding: 8px 0;
+    background: transparent;
+}
+[data-dashboard="true"] .burnish-node {
+    box-shadow: none;
+}
+[data-dashboard="true"] .burnish-node + .burnish-node {
+    margin-top: 0;
+}
+[data-dashboard="true"] .burnish-empty-state { display: none; }
+#btn-dashboard-toggle.active {
+    color: white;
+    background: rgba(255,255,255,0.15);
+}
+
 /* ── Responsive ── */
 @media (max-width: 768px) {
     .burnish-session-panel { left: -260px; transition: left var(--burnish-transition-normal); }


### PR DESCRIPTION
## Summary
- Adds grid icon toggle button in the header bar
- Dashboard mode hides session panel, prompt bar, node headers, and prompt bubbles
- Shows only visual components in a clean layout
- Persists to localStorage, survives page reload

Closes #4

## Test plan
- [ ] `pnpm build` passes
- [ ] Click toggle — clean dashboard view with only components visible
- [ ] Click again — conversation view restored
- [ ] Reload page — dashboard mode persists