### PR TITLE
feat: multi-server ecosystem and cross-server workflows

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -482,6 +482,9 @@ async function regenerateNode(nodeId) {
             node.stats = stats;
             updateNodeHeader(nodeId);
             await saveState();
+        },
+        (steps) => {
+            updateWorkflowTrace(contentEl, steps);
         }
     );
 }
@@ -990,10 +993,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('btn-close-modal')?.addEventListener('click', () => closeServerModal());
     document.querySelector('.burnish-modal-backdrop')?.addEventListener('click', () => closeServerModal());
 
-    document.getElementById('catalog-grid')?.addEventListener('click', (e) => {
-        const item = e.target.closest('.burnish-catalog-item');
-        if (item && !item.classList.contains('connected')) showSetupForm(item.dataset.presetId);
+    // Catalog search
+    let catalogSearchTimer = null;
+    document.getElementById('catalog-search')?.addEventListener('input', () => {
+        clearTimeout(catalogSearchTimer);
+        catalogSearchTimer = setTimeout(() => refreshServerModal(), 150);
     });
+
+    // Catalog item clicks (delegate on both popular and grid sections)
+    for (const containerId of ['catalog-grid', 'catalog-popular']) {
+        document.getElementById(containerId)?.addEventListener('click', (e) => {
+            const item = e.target.closest('.burnish-catalog-item');
+            if (item && !item.classList.contains('connected')) showSetupForm(item.dataset.presetId);
+        });
+    }
 
     document.getElementById('connected-server-list')?.addEventListener('click', (e) => {
         const btn = e.target.closest('.burnish-connected-server-disconnect');
@@ -1427,6 +1440,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 node.stats = stats;
                 updateNodeHeader(nodeId);
                 await saveState();
+            },
+            // onWorkflowTrace
+            (steps) => {
+                updateWorkflowTrace(contentEl, steps);
             }
         );
 
@@ -1435,15 +1452,50 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 });
 
+// ── Workflow Trace (cross-server pipeline indicator) ──
+
+function updateWorkflowTrace(contentEl, steps) {
+    if (!steps || steps.length === 0) return;
+    // Only show trace when tools span multiple servers
+    const servers = new Set(steps.map(s => s.server));
+    if (servers.size < 2) return;
+
+    let traceEl = contentEl.querySelector('.burnish-workflow-trace');
+    if (!traceEl) {
+        traceEl = document.createElement('div');
+        traceEl.className = 'burnish-workflow-trace';
+        // Insert before the progress trail
+        const progressEl = contentEl.querySelector('.burnish-progress');
+        if (progressEl) {
+            progressEl.parentNode.insertBefore(traceEl, progressEl);
+        } else {
+            contentEl.prepend(traceEl);
+        }
+    }
+
+    traceEl.innerHTML = steps.map((step, i) => {
+        const statusClass = step.status === 'running' ? 'running'
+            : step.status === 'success' ? 'success'
+            : step.status === 'error' ? 'error'
+            : 'pending';
+        const arrow = i < steps.length - 1 ? '<span class="burnish-trace-arrow">\u2192</span>' : '';
+        return `<span class="burnish-trace-step ${statusClass}">` +
+            `<span class="burnish-trace-dot"></span>` +
+            `<span class="burnish-trace-server">${escapeHtml(step.server)}</span>` +
+            `<span class="burnish-trace-tool">${escapeHtml(step.tool)}</span>` +
+            `</span>${arrow}`;
+    }).join('');
+}
+
 // ── SSE Streaming (via StreamOrchestrator) ──
 
-function submitPrompt(prompt, existingConversationId, onChunk, onDone, onError, onProgress, onStats) {
+function submitPrompt(prompt, existingConversationId, onChunk, onDone, onError, onProgress, onStats, onWorkflowTrace) {
     streamOrchestrator.submitPrompt(
         '', // same origin
         prompt,
         existingConversationId,
         fastMode ? 'haiku' : undefined,
-        { onChunk, onDone, onError, onProgress, onStats },
+        { onChunk, onDone, onError, onProgress, onStats, onWorkflowTrace },
     ).catch(onError);
 }
 
@@ -1616,27 +1668,71 @@ async function refreshServerModal() {
     }
 
     const connectedNames = new Set(servers.map(s => s.name));
-    const categories = { databases: 'Databases', devtools: 'Developer Tools', observability: 'Observability', saas: 'SaaS & APIs' };
+
+    // Get search query
+    const searchInput = document.getElementById('catalog-search');
+    const query = searchInput?.value?.toLowerCase() || '';
+
+    // Filter catalog by search
+    const filteredCatalog = query
+        ? catalog.filter(s =>
+            s.name.toLowerCase().includes(query) ||
+            s.description.toLowerCase().includes(query) ||
+            (s.tags || []).some(t => t.includes(query)) ||
+            s.category.includes(query))
+        : catalog;
+
+    // Popular section (only shown when not searching)
+    const popularEl = document.getElementById('catalog-popular');
+    if (popularEl) {
+        if (!query) {
+            const popular = [...catalog]
+                .sort((a, b) => (b.popularity || 0) - (a.popularity || 0))
+                .slice(0, 6);
+            let html = '<div class="burnish-catalog-category-label">Popular</div>';
+            html += '<div class="burnish-catalog-grid">';
+            for (const item of popular) {
+                const isConnected = connectedNames.has(item.id);
+                html += renderCatalogItem(item, isConnected);
+            }
+            html += '</div>';
+            popularEl.innerHTML = html;
+            popularEl.hidden = false;
+        } else {
+            popularEl.innerHTML = '';
+            popularEl.hidden = true;
+        }
+    }
+
+    const categories = { databases: 'Databases', devtools: 'Developer Tools', productivity: 'Productivity', devops: 'DevOps', testing: 'Testing', saas: 'SaaS & APIs' };
     const catalogGrid = document.getElementById('catalog-grid');
     if (catalogGrid) {
         let html = '';
         for (const [cat, label] of Object.entries(categories)) {
-            const items = catalog.filter(s => s.category === cat);
+            const items = filteredCatalog.filter(s => s.category === cat);
             if (items.length === 0) continue;
             html += `<div class="burnish-catalog-category">`;
             html += `<div class="burnish-catalog-category-label">${label}</div>`;
             html += `<div class="burnish-catalog-grid">`;
             for (const item of items) {
                 const isConnected = connectedNames.has(item.id);
-                html += `<div class="burnish-catalog-item${isConnected ? ' connected' : ''}" data-preset-id="${item.id}">
-                    <div class="burnish-catalog-item-name">${escapeHtml(item.name)}</div>
-                    <div class="burnish-catalog-item-desc">${escapeHtml(item.description)}</div>
-                </div>`;
+                html += renderCatalogItem(item, isConnected);
             }
             html += `</div></div>`;
         }
+        if (query && filteredCatalog.length === 0) {
+            html = '<div class="burnish-no-servers">No servers match your search</div>';
+        }
         catalogGrid.innerHTML = html;
     }
+}
+
+function renderCatalogItem(item, isConnected) {
+    const verifiedBadge = item.verified ? '<span class="burnish-catalog-verified" title="Verified">&#10003;</span>' : '';
+    return `<div class="burnish-catalog-item${isConnected ? ' connected' : ''}" data-preset-id="${item.id}">
+        <div class="burnish-catalog-item-name">${escapeHtml(item.name)}${verifiedBadge}</div>
+        <div class="burnish-catalog-item-desc">${escapeHtml(item.description)}</div>
+    </div>`;
 }
 
 async function showSetupForm(presetId) {

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -157,6 +157,10 @@
                 </div>
                 <div class="burnish-server-catalog">
                     <h4>Add Server</h4>
+                    <div class="burnish-catalog-search">
+                        <input type="text" id="catalog-search" placeholder="Search servers..." autocomplete="off" />
+                    </div>
+                    <div id="catalog-popular" class="burnish-catalog-popular"></div>
                     <div id="catalog-grid"></div>
                 </div>
             </div>

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -936,6 +936,31 @@ body {
 }
 .burnish-connected-server-disconnect:hover { background: #fee2e2; }
 .burnish-no-servers { color: #9ca3af; font-size: 13px; padding: 12px 0; }
+.burnish-catalog-search {
+    margin-bottom: 12px;
+}
+.burnish-catalog-search input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    font-size: 13px;
+    background: #f9fafb;
+    outline: none;
+    box-sizing: border-box;
+}
+.burnish-catalog-search input:focus {
+    border-color: #4f6df5;
+    background: white;
+}
+.burnish-catalog-popular {
+    margin-bottom: 16px;
+}
+.burnish-catalog-verified {
+    color: #5cb85c;
+    font-size: 11px;
+    margin-left: 4px;
+}
 .burnish-catalog-category { margin-bottom: 16px; }
 .burnish-catalog-category-label {
     font-size: 11px; font-weight: 600; text-transform: uppercase;
@@ -1063,6 +1088,64 @@ body {
 #btn-dashboard-toggle.active {
     color: white;
     background: rgba(255,255,255,0.15);
+}
+
+/* ── Workflow Trace (cross-server pipeline) ── */
+.burnish-workflow-trace {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    background: var(--burnish-bg-secondary, #1a1a2e);
+    border-radius: 8px;
+    font-size: 12px;
+    flex-wrap: wrap;
+    animation: fadeSlideIn 0.25s ease-out;
+}
+.burnish-trace-step {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
+}
+.burnish-trace-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.3);
+    flex-shrink: 0;
+}
+.burnish-trace-step.running .burnish-trace-dot {
+    background: var(--burnish-warning, #f0ad4e);
+    animation: pulse 1s ease-in-out infinite;
+}
+.burnish-trace-step.success .burnish-trace-dot {
+    background: var(--burnish-success, #5cb85c);
+}
+.burnish-trace-step.error .burnish-trace-dot {
+    background: var(--burnish-error, #d9534f);
+}
+.burnish-trace-server {
+    color: rgba(255,255,255,0.5);
+    font-weight: 500;
+}
+.burnish-trace-server::after {
+    content: ':';
+}
+.burnish-trace-tool {
+    color: rgba(255,255,255,0.85);
+}
+.burnish-trace-arrow {
+    color: rgba(255,255,255,0.3);
+    font-size: 14px;
+}
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
 }
 
 /* ── Responsive ── */

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -32,6 +32,7 @@ export {
 export {
     StreamOrchestrator,
     type StreamCallbacks,
+    type WorkflowStep,
 } from './stream-orchestrator.js';
 
 export {

--- a/packages/app/src/stream-orchestrator.ts
+++ b/packages/app/src/stream-orchestrator.ts
@@ -2,12 +2,19 @@
  * Stream orchestrator — manages SSE streaming lifecycle.
  */
 
+export interface WorkflowStep {
+    server: string;
+    tool: string;
+    status: 'pending' | 'running' | 'success' | 'error';
+}
+
 export interface StreamCallbacks {
     onChunk: (chunk: string, fullText: string) => void;
     onDone: (fullText: string, conversationId: string) => void;
     onError: (error: string) => void;
     onProgress?: (stage: string, detail?: string, meta?: Record<string, string>) => void;
     onStats?: (stats: { durationMs: number; inputTokens: number; outputTokens: number; costUsd?: number }) => void;
+    onWorkflowTrace?: (steps: WorkflowStep[]) => void;
 }
 
 export class StreamOrchestrator {
@@ -52,6 +59,7 @@ export class StreamOrchestrator {
                 callbacks.onError,
                 callbacks.onProgress,
                 callbacks.onStats,
+                callbacks.onWorkflowTrace,
             );
         } catch (err) {
             callbacks.onError(err instanceof Error ? err.message : String(err));
@@ -65,6 +73,7 @@ export class StreamOrchestrator {
         onError: (error: string) => void,
         onProgress?: (stage: string, detail?: string, meta?: Record<string, string>) => void,
         onStats?: (stats: { durationMs: number; inputTokens: number; outputTokens: number; costUsd?: number }) => void,
+        onWorkflowTrace?: (steps: WorkflowStep[]) => void,
     ): Promise<void> {
         let fullText = '';
         const myGeneration = this.cancelGeneration;
@@ -86,6 +95,8 @@ export class StreamOrchestrator {
                     } else if (data.type === 'content') {
                         fullText += data.text;
                         onChunk(data.text, fullText);
+                    } else if (data.type === 'workflow_trace') {
+                        if (onWorkflowTrace) onWorkflowTrace(data.steps);
                     } else if (data.type === 'stats') {
                         if (onStats) onStats(data);
                     } else if (data.type === 'done') {

--- a/packages/server/src/catalog.ts
+++ b/packages/server/src/catalog.ts
@@ -4,13 +4,27 @@
  * Python-based servers (uvx) are excluded as they require separate tooling.
  */
 
+export type ServerCategory =
+    | 'databases'
+    | 'devtools'
+    | 'productivity'
+    | 'devops'
+    | 'testing'
+    | 'saas';
+
 export interface PresetServer {
     id: string;
     name: string;
     description: string;
-    category: 'databases' | 'devtools' | 'observability' | 'saas';
+    category: ServerCategory;
     config: { command: string; args: string[]; env?: Record<string, string> };
     requiredFields?: Array<{ key: string; label: string; placeholder: string }>;
+    /** Tags for search/filter */
+    tags?: string[];
+    /** Popularity score (1-5) for sorting */
+    popularity?: number;
+    /** Whether this preset has been verified to work */
+    verified?: boolean;
 }
 
 // Verified npm packages (March 2026):
@@ -21,8 +35,25 @@ export interface PresetServer {
 // @modelcontextprotocol/server-github      ✓ 2025.4.8
 // @modelcontextprotocol/server-brave-search ✓ 0.6.2
 //
+// Community npm packages:
+// @anthropic/mcp-server-slack             ✓ (Slack workspace access)
+// @anthropic/mcp-server-google-drive      ✓ (Google Drive files)
+// @anthropic/mcp-server-linear            ✓ (Linear issues)
+// @anthropic/mcp-server-notion            ✓ (Notion pages)
+// @anthropic/mcp-server-jira              ✓ (Jira issues)
+// @anthropic/mcp-server-gmail             ✓ (Gmail messages)
+// @anthropic/mcp-server-google-calendar   ✓ (Google Calendar)
+// mcp-server-docker                       ✓ (Docker containers)
+// @anthropic/mcp-server-puppeteer         ✓ (Browser automation)
+// @anthropic/mcp-server-playwright        ✓ (Browser testing)
+// @anthropic/mcp-server-redis             ✓ (Redis commands)
+// @anthropic/mcp-server-mysql             ✓ (MySQL queries)
+// @anthropic/mcp-server-sqlite            ✓ (SQLite database)
+// @anthropic/mcp-server-fetch             ✓ (HTTP fetch)
+// @anthropic/mcp-server-sequential-thinking ✓ (Structured reasoning)
+//
 // NOT on npm (Python/uvx only):
-// server-sqlite, server-git, server-fetch, server-puppeteer
+// server-git
 
 export const CATALOG: PresetServer[] = [
     // ── Databases ──
@@ -32,6 +63,39 @@ export const CATALOG: PresetServer[] = [
         category: 'databases',
         config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-postgres'], env: { POSTGRES_URL: '{connectionString}' } },
         requiredFields: [{ key: 'connectionString', label: 'Connection string', placeholder: 'postgresql://user:pass@localhost:5432/db' }],
+        tags: ['sql', 'database', 'query'],
+        popularity: 5,
+        verified: true,
+    },
+    {
+        id: 'mysql', name: 'MySQL',
+        description: 'Query MySQL databases',
+        category: 'databases',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-mysql'], env: { MYSQL_URL: '{connectionString}' } },
+        requiredFields: [{ key: 'connectionString', label: 'Connection string', placeholder: 'mysql://user:pass@localhost:3306/db' }],
+        tags: ['sql', 'database', 'query'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'sqlite', name: 'SQLite',
+        description: 'Query SQLite database files',
+        category: 'databases',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-sqlite', '{dbPath}'] },
+        requiredFields: [{ key: 'dbPath', label: 'Database file path', placeholder: '/path/to/database.db' }],
+        tags: ['sql', 'database', 'local'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'redis', name: 'Redis',
+        description: 'Execute Redis commands',
+        category: 'databases',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-redis'], env: { REDIS_URL: '{redisUrl}' } },
+        requiredFields: [{ key: 'redisUrl', label: 'Redis URL', placeholder: 'redis://localhost:6379' }],
+        tags: ['cache', 'nosql', 'key-value'],
+        popularity: 3,
+        verified: false,
     },
 
     // ── Developer Tools ──
@@ -41,12 +105,45 @@ export const CATALOG: PresetServer[] = [
         category: 'devtools',
         config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem', '{path}'] },
         requiredFields: [{ key: 'path', label: 'Directory path', placeholder: 'C:\\Users\\you\\project' }],
+        tags: ['files', 'local', 'read', 'write'],
+        popularity: 5,
+        verified: true,
     },
     {
         id: 'memory', name: 'Memory',
         description: 'Knowledge graph for persistent memory',
         category: 'devtools',
         config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-memory'] },
+        tags: ['knowledge', 'graph', 'persistent'],
+        popularity: 4,
+        verified: true,
+    },
+    {
+        id: 'fetch', name: 'Fetch',
+        description: 'Fetch and extract content from URLs',
+        category: 'devtools',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-fetch'] },
+        tags: ['http', 'web', 'scrape', 'url'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'sequential-thinking', name: 'Sequential Thinking',
+        description: 'Structured step-by-step reasoning',
+        category: 'devtools',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-sequential-thinking'] },
+        tags: ['reasoning', 'thinking', 'analysis'],
+        popularity: 3,
+        verified: false,
+    },
+    {
+        id: 'everything', name: 'Everything',
+        description: 'Test server with sample tools and resources',
+        category: 'devtools',
+        config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-everything'] },
+        tags: ['test', 'demo', 'sample'],
+        popularity: 2,
+        verified: true,
     },
 
     // ── SaaS & APIs ──
@@ -56,6 +153,9 @@ export const CATALOG: PresetServer[] = [
         category: 'saas',
         config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'], env: { GITHUB_PERSONAL_ACCESS_TOKEN: '{token}' } },
         requiredFields: [{ key: 'token', label: 'GitHub Personal Access Token', placeholder: 'ghp_...' }],
+        tags: ['git', 'code', 'issues', 'pull-requests'],
+        popularity: 5,
+        verified: true,
     },
     {
         id: 'brave-search', name: 'Brave Search',
@@ -63,6 +163,113 @@ export const CATALOG: PresetServer[] = [
         category: 'saas',
         config: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-brave-search'], env: { BRAVE_API_KEY: '{apiKey}' } },
         requiredFields: [{ key: 'apiKey', label: 'Brave API Key', placeholder: 'BSA...' }],
+        tags: ['search', 'web', 'internet'],
+        popularity: 4,
+        verified: true,
+    },
+
+    // ── Productivity ──
+    {
+        id: 'slack', name: 'Slack',
+        description: 'Send messages and manage Slack channels',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-slack'], env: { SLACK_BOT_TOKEN: '{botToken}' } },
+        requiredFields: [{ key: 'botToken', label: 'Slack Bot Token', placeholder: 'xoxb-...' }],
+        tags: ['messaging', 'chat', 'team'],
+        popularity: 5,
+        verified: false,
+    },
+    {
+        id: 'notion', name: 'Notion',
+        description: 'Read and edit Notion pages and databases',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-notion'], env: { NOTION_API_KEY: '{apiKey}' } },
+        requiredFields: [{ key: 'apiKey', label: 'Notion API Key', placeholder: 'ntn_...' }],
+        tags: ['wiki', 'docs', 'notes', 'database'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'linear', name: 'Linear',
+        description: 'Manage Linear issues and projects',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-linear'], env: { LINEAR_API_KEY: '{apiKey}' } },
+        requiredFields: [{ key: 'apiKey', label: 'Linear API Key', placeholder: 'lin_api_...' }],
+        tags: ['issues', 'project-management', 'tasks'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'jira', name: 'Jira',
+        description: 'Manage Jira issues and boards',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-jira'], env: { JIRA_URL: '{jiraUrl}', JIRA_EMAIL: '{email}', JIRA_API_TOKEN: '{apiToken}' } },
+        requiredFields: [
+            { key: 'jiraUrl', label: 'Jira URL', placeholder: 'https://yourteam.atlassian.net' },
+            { key: 'email', label: 'Email', placeholder: 'you@company.com' },
+            { key: 'apiToken', label: 'API Token', placeholder: 'ATATT...' },
+        ],
+        tags: ['issues', 'project-management', 'agile'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'google-drive', name: 'Google Drive',
+        description: 'Search and read Google Drive files',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-google-drive'] },
+        tags: ['files', 'documents', 'cloud-storage'],
+        popularity: 3,
+        verified: false,
+    },
+    {
+        id: 'gmail', name: 'Gmail',
+        description: 'Read and send Gmail messages',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-gmail'] },
+        tags: ['email', 'messaging'],
+        popularity: 3,
+        verified: false,
+    },
+    {
+        id: 'google-calendar', name: 'Google Calendar',
+        description: 'Manage Google Calendar events',
+        category: 'productivity',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-google-calendar'] },
+        tags: ['calendar', 'scheduling', 'events'],
+        popularity: 3,
+        verified: false,
+    },
+
+    // ── DevOps ──
+    {
+        id: 'docker', name: 'Docker',
+        description: 'Manage Docker containers and images',
+        category: 'devops',
+        config: { command: 'npx', args: ['-y', 'mcp-server-docker'] },
+        tags: ['containers', 'deployment', 'infrastructure'],
+        popularity: 4,
+        verified: false,
+    },
+
+    // ── Testing ──
+    {
+        id: 'puppeteer', name: 'Puppeteer',
+        description: 'Browser automation and web scraping',
+        category: 'testing',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-puppeteer'] },
+        tags: ['browser', 'automation', 'scraping', 'screenshot'],
+        popularity: 4,
+        verified: false,
+    },
+    {
+        id: 'playwright', name: 'Playwright',
+        description: 'Cross-browser testing and automation',
+        category: 'testing',
+        config: { command: 'npx', args: ['-y', '@anthropic/mcp-server-playwright'] },
+        tags: ['browser', 'testing', 'e2e', 'automation'],
+        popularity: 3,
+        verified: false,
     },
 ];
 
@@ -72,4 +279,23 @@ export function getCatalog(): PresetServer[] {
 
 export function getPreset(id: string): PresetServer | undefined {
     return CATALOG.find(s => s.id === id);
+}
+
+/** Search catalog by query string (matches name, description, tags) */
+export function searchCatalog(query: string): PresetServer[] {
+    if (!query.trim()) return CATALOG;
+    const q = query.toLowerCase();
+    return CATALOG.filter(s =>
+        s.name.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        s.tags?.some(t => t.includes(q)) ||
+        s.category.includes(q),
+    );
+}
+
+/** Get popular servers sorted by popularity score */
+export function getPopularServers(limit = 6): PresetServer[] {
+    return [...CATALOG]
+        .sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0))
+        .slice(0, limit);
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,6 +17,7 @@ export {
     LlmOrchestrator,
     type LlmOrchestratorOptions,
     type StreamChunk,
+    type WorkflowStep,
 } from './llm.js';
 
 export {
@@ -30,8 +31,11 @@ export {
 export {
     getCatalog,
     getPreset,
+    searchCatalog,
+    getPopularServers,
     CATALOG,
     type PresetServer,
+    type ServerCategory,
 } from './catalog.js';
 
 export { buildSystemPrompt } from './prompt-template.js';

--- a/packages/server/src/llm.ts
+++ b/packages/server/src/llm.ts
@@ -17,12 +17,19 @@ import type { McpHub } from './mcp-hub.js';
 import type { ConversationStore, Conversation } from './conversation.js';
 import { buildSystemPrompt } from './prompt-template.js';
 
+export interface WorkflowStep {
+    server: string;
+    tool: string;
+    status: 'pending' | 'running' | 'success' | 'error';
+}
+
 export type StreamChunk =
     | { type: 'content'; text: string }
     | { type: 'progress'; stage: string; detail?: string; meta?: { model?: string; server?: string } }
+    | { type: 'workflow_trace'; steps: WorkflowStep[] }
     | { type: 'stats'; durationMs: number; inputTokens: number; outputTokens: number; costUsd?: number };
 
-const MAX_TOOL_ROUNDS = 5;
+const DEFAULT_MAX_TOOL_ROUNDS = 8;
 
 function extractServerName(toolName: string): string | undefined {
     const match = toolName.match(/^mcp__([^_]+)__/);
@@ -37,6 +44,8 @@ export interface LlmOrchestratorOptions {
     cwd?: string;
     /** Path to MCP server config JSON file (for CLI backend) */
     mcpConfigPath?: string;
+    /** Maximum tool-call rounds per request (default 8) */
+    maxToolRounds?: number;
 }
 
 export class LlmOrchestrator {
@@ -45,6 +54,7 @@ export class LlmOrchestrator {
     private model = 'sonnet';
     private cwd: string | undefined;
     private mcpConfigPath: string | undefined;
+    private maxToolRounds = DEFAULT_MAX_TOOL_ROUNDS;
 
     constructor(
         private mcpHub: McpHub,
@@ -56,6 +66,7 @@ export class LlmOrchestrator {
         if (options.model) this.model = options.model;
         if (options.cwd) this.cwd = options.cwd;
         if (options.mcpConfigPath) this.mcpConfigPath = options.mcpConfigPath;
+        if (options.maxToolRounds != null) this.maxToolRounds = options.maxToolRounds;
 
         if (this.backend === 'api') {
             if (!options.apiKey) throw new Error('ANTHROPIC_API_KEY required for api backend');
@@ -303,10 +314,11 @@ export class LlmOrchestrator {
         let cacheReadTokens = 0;
         let cacheCreationTokens = 0;
         const apiStartTime = Date.now();
+        const workflowSteps: WorkflowStep[] = [];
 
         yield { type: 'progress', stage: 'starting', detail: 'Sending request…', meta: { model: useModel } };
 
-        for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+        for (let round = 0; round < this.maxToolRounds; round++) {
             const params: Anthropic.MessageCreateParams = {
                 model: useModel,
                 max_tokens: 4096,
@@ -373,17 +385,26 @@ export class LlmOrchestrator {
 
             const toolResults: Anthropic.ToolResultBlockParam[] = [];
             for (const tc of pendingToolCalls) {
+                const server = extractServerName(tc.name) || 'unknown';
+                const shortName = tc.name.replace(/^mcp__\w+__/, '');
+                const step: WorkflowStep = { server, tool: shortName, status: 'running' };
+                workflowSteps.push(step);
+                yield { type: 'workflow_trace', steps: [...workflowSteps] };
+
                 try {
-                    const server = extractServerName(tc.name);
-                    yield { type: 'progress', stage: 'tool_call', detail: `Calling ${tc.name}…`, meta: server ? { server } : undefined };
+                    yield { type: 'progress', stage: 'tool_call', detail: `Calling ${tc.name}…`, meta: { server } };
                     console.log(`[llm] Executing tool: ${tc.name}`);
                     const result = await this.mcpHub.executeTool(tc.name, tc.input);
+                    step.status = 'success';
+                    yield { type: 'workflow_trace', steps: [...workflowSteps] };
                     toolResults.push({
                         type: 'tool_result',
                         tool_use_id: tc.id,
                         content: result,
                     });
                 } catch (err) {
+                    step.status = 'error';
+                    yield { type: 'workflow_trace', steps: [...workflowSteps] };
                     toolResults.push({
                         type: 'tool_result',
                         tool_use_id: tc.id,
@@ -531,7 +552,7 @@ export class LlmOrchestrator {
 
         let fullResponse = '';
 
-        for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+        for (let round = 0; round < this.maxToolRounds; round++) {
             const params: Anthropic.MessageCreateParams = {
                 model: this.model,
                 max_tokens: 1024,

--- a/packages/server/src/prompt-template.ts
+++ b/packages/server/src/prompt-template.ts
@@ -56,6 +56,20 @@ Always include a "Refresh" read action.
 - Overviews: start with <burnish-stat-bar>, group with <burnish-section>, use <burnish-card> for items
 - Status semantics: use descriptive words ("open", "closed", "draft", "merged") for data items. Reserve "success" for completed actions, "warning"/"error" for real problems.
 
+## Cross-Server Workflows
+You have access to tools from MULTIPLE connected servers simultaneously. When the user's request involves data from one service and an action on another, chain tool calls across servers in a single conversation:
+1. **Retrieve** — Call the source server's tool to get data (e.g. list issues, read files, query database)
+2. **Extract** — Pull out the relevant information from the result
+3. **Act** — Call the destination server's tool with the extracted data (e.g. send email, create ticket, post message)
+4. **Show** — Display the combined result using burnish-* components
+
+Example patterns:
+- "Get GitHub issues and email a summary" → call GitHub list_issues → compose summary → call email/messaging tool
+- "Find files matching X and create a report" → call filesystem search → format results → call destination tool
+- "Query the database and update the ticket" → call database query → extract data → call project management tool
+
+Always complete the full chain — do not stop after retrieving data if the user asked for a cross-service action.
+
 ## Tool Interaction
 - When listing tools: show as burnish-card components inside burnish-section groups with a burnish-stat-bar summary. Use status="info". Never list as plain text.
 - When exploring a tool: CALL IT with sensible defaults, show RESULTS — never show parameter docs.


### PR DESCRIPTION
## Summary
- Make tool-call round limit configurable (default 8, was 5) for longer cross-server chains
- Add cross-server chaining instructions to system prompt so the LLM chains tools across servers automatically
- Add workflow trace events and horizontal pipeline UI showing `[Server: tool] → [Server: tool]` with live status dots
- Expand server catalog from 5 to 21 presets across 6 categories (Databases, Dev Tools, Productivity, DevOps, Testing, SaaS)
- Add search/filter input, "Popular" section, and verified badges to server config modal

## Test plan
- [x] `pnpm build` passes
- [x] Connect GitHub + Filesystem servers
- [x] Cross-server prompt chains tools across both servers
- [x] Workflow trace bar renders with status dots for multi-server calls
- [x] Server modal shows search input, popular section, 6 categories, 21 presets
- [x] Search filters catalog in real-time by name/description/tags