### PR TITLE
fix: show message instead of empty panel on empty LLM response

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -438,6 +438,16 @@ async function regenerateNode(nodeId) {
             node.response = trimmed;
             node.type = containsBurnishTags(trimmed) ? 'components' : 'text';
 
+            if (!trimmed) {
+                contentEl.innerHTML = '<div class="burnish-text-response" style="color: var(--burnish-text-muted, #9ca3af); font-style: italic;">No response received. Try regenerating.</div>';
+                node.type = 'text';
+                updateNodeSummary(nodeId);
+                updateBreadcrumb();
+                renderSessionList();
+                await saveState();
+                return;
+            }
+
             if (containsBurnishTags(trimmed)) {
                 // Always apply transformOutput on completion to ensure
                 // color normalization rules run (streaming bypasses them)
@@ -1325,6 +1335,16 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const trimmed = fullText.trim();
                 node.response = trimmed;
                 node.type = containsBurnishTags(trimmed) ? 'components' : 'text';
+
+                if (!trimmed) {
+                    contentEl.innerHTML = '<div class="burnish-text-response" style="color: var(--burnish-text-muted, #9ca3af); font-style: italic;">No response received. Try regenerating.</div>';
+                    node.type = 'text';
+                    updateNodeSummary(nodeId);
+                    updateBreadcrumb();
+                    renderSessionList();
+                    await saveState();
+                    return;
+                }
 
                 if (containsBurnishTags(trimmed)) {
                     // Always apply transformOutput on completion to ensure


### PR DESCRIPTION
## Summary
- Adds empty-response guard in both `regenerateNode()` and `handleSubmit()` onDone callbacks
- When `trimmed` is empty/falsy, renders a muted italic message "No response received. Try regenerating." instead of a blank panel
- Early-returns after rendering the message to avoid further processing of empty content

Closes #52

## Test plan
- [ ] Start with `pnpm dev:cli`
- [ ] Submit a prompt that generates results
- [ ] Click the refresh button on a result panel
- [ ] If the LLM returns empty, verify the muted message appears instead of a blank panel
- [ ] Verify normal non-empty responses still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)