### PR TITLE
fix: preserve tool call context in CLI backend multi-turn messages

### DIFF
--- a/packages/server/src/llm.ts
+++ b/packages/server/src/llm.ts
@@ -254,6 +254,15 @@ export class LlmOrchestrator {
             return conv.messages[0].content;
         }
 
+        // If the latest user message is a direct tool invocation (e.g. from a form
+        // submission), it already contains all needed context (tool name + params).
+        // Including truncated history would strip the tool context the LLM needs,
+        // so we return only the tool-call instruction.
+        const lastMsg = conv.messages[conv.messages.length - 1];
+        if (lastMsg.role === 'user' && /^Call the tool\b/i.test(lastMsg.content)) {
+            return lastMsg.content;
+        }
+
         return conv.messages
             .map(m => {
                 if (m.role === 'user') return `User: ${m.content}`;


### PR DESCRIPTION
## Summary
- When the CLI backend builds multi-turn messages, direct tool invocations (form submissions like `search_repositories`) were losing context because prior assistant responses were truncated to `[Previous dashboard response]`
- Now, when the latest user message starts with "Call the tool", only that message is sent (no history), since it already contains all needed context (tool name + parameters)
- Build passes, single-file change in `packages/server/src/llm.ts`

Closes #51

## Test plan
- [ ] Start demo with CLI backend (`pnpm dev:cli`) connected to GitHub MCP server
- [ ] Ask to see GitHub tools, then submit a `search_repositories` form with a query
- [ ] Verify the tool executes and returns results instead of empty/confused output

🤖 Generated with [Claude Code](https://claude.com/claude-code)