### PR TITLE
fix: client-side security hardening (SRI, sanitization, input validation)

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -27,6 +27,8 @@ const PURIFY_CONFIG = {
                'status-field', 'type', 'config', 'role', 'content', 'class',
                'label', 'count', 'collapsed', 'item-id', 'value', 'unit', 'trend',
                'streaming', 'tool-id', 'fields', 'actions', 'color'],
+    FORBID_TAGS: ['script', 'iframe', 'object', 'embed', 'form'],
+    FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
 };
 
 
@@ -1496,7 +1498,7 @@ function extractContent(text) {
 function renderMarkdown(text) {
     if (typeof marked !== 'undefined') {
         const html = marked.parse(text);
-        return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(html) : html;
+        return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(html, PURIFY_CONFIG) : html;
     }
     const div = document.createElement('div');
     div.textContent = text;

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -28,13 +28,19 @@
     </script>
 
     <!-- Chart.js for burnish-chart -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"
+            integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+            crossorigin="anonymous"></script>
 
     <!-- DOMPurify for HTML sanitization -->
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"
+            integrity="sha384-pcBjnGbkyKeOXaoFkmJiuR9E08/6gkmus6/Strimnxtl3uk0Hx23v345pWyC/MMr"
+            crossorigin="anonymous"></script>
 
     <!-- Marked.js for markdown rendering -->
-    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"
+            integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi"
+            crossorigin="anonymous"></script>
 
     <!-- Burnish Components (CDN-style from local build) -->
     <script type="module" src="/components/card.js"></script>

--- a/packages/app/src/drill-down.ts
+++ b/packages/app/src/drill-down.ts
@@ -6,6 +6,17 @@
 // (this package runs in the browser, server runs in Node)
 const WRITE_TOOL_PATTERNS = /^(create|update|delete|remove|push|write|edit|move|fork|merge|add|set|close|lock|assign)/i;
 
+/** Max length for sanitized drill-down inputs */
+const MAX_INPUT_LENGTH = 500;
+
+/**
+ * Strip control characters (ASCII 0-8, 11, 12, 14-31) and truncate to max length.
+ */
+function sanitizeInput(input: string, maxLength = MAX_INPUT_LENGTH): string {
+    // eslint-disable-next-line no-control-regex
+    return input.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '').slice(0, maxLength);
+}
+
 /**
  * Classify a tool as a write/mutate operation based on its name.
  */
@@ -20,6 +31,10 @@ export function isWriteTool(toolName: string): boolean {
  * Build the drill-down prompt for a card click.
  */
 export function getDrillDownPrompt(title: string, status?: string, itemId?: string): string {
+    title = sanitizeInput(title);
+    if (status) status = sanitizeInput(status);
+    if (itemId) itemId = sanitizeInput(itemId);
+
     const idClause = itemId ? ` (tool: ${itemId})` : '';
     const looksLikeTool = itemId && (itemId.includes('__') || itemId.includes('mcp_'));
 

--- a/packages/app/src/output-transformer.ts
+++ b/packages/app/src/output-transformer.ts
@@ -19,7 +19,17 @@ const STATUS_COLOR_MAP: Record<string, string> = {
     muted: 'var(--burnish-muted, #9ca3af)',
 };
 
+/** Maximum HTML input size for transformation (2 MB) */
+const MAX_HTML_INPUT_SIZE = 2 * 1024 * 1024;
+
 export function transformOutput(html: string, options?: TransformOutputOptions): string {
+    // Validate input
+    if (!html || typeof html !== 'string') return '';
+    if (html.length > MAX_HTML_INPUT_SIZE) {
+        console.warn('transformOutput: input exceeds maximum size, truncating');
+        html = html.slice(0, MAX_HTML_INPUT_SIZE);
+    }
+
     if (!options?.domParser && typeof DOMParser === 'undefined') {
         // No DOMParser available (Node.js) and none injected — return html unchanged
         return html;

--- a/packages/app/src/session-store.ts
+++ b/packages/app/src/session-store.ts
@@ -46,6 +46,11 @@ export interface AppSession {
     _nodeIds?: string[];
 }
 
+/** Maximum number of sessions allowed */
+const MAX_SESSIONS = 100;
+/** Maximum total storage size in bytes (10 MB) */
+const MAX_STORAGE_BYTES = 10 * 1024 * 1024;
+
 export class SessionStore {
     private sessionDb: UseStore;
     private nodeDb: UseStore;
@@ -77,6 +82,46 @@ export class SessionStore {
 
     async save(sessions: AppSession[], activeSessionId: string | null): Promise<void> {
         try {
+            // Enforce session count limit — evict oldest sessions first
+            if (sessions.length > MAX_SESSIONS) {
+                const sorted = [...sessions].sort((a, b) => a.updatedAt - b.updatedAt);
+                const toEvict = sorted.slice(0, sessions.length - MAX_SESSIONS);
+                const evictIds = new Set(toEvict.map(s => s.id));
+                // Delete evicted session nodes
+                for (const s of toEvict) {
+                    const nodeIds = this._loadedSessionIds.has(s.id)
+                        ? s.nodes.map(n => n.id)
+                        : (s._nodeIds || []);
+                    if (nodeIds.length > 0) await this.deleteNodes(nodeIds);
+                    this._loadedSessionIds.delete(s.id);
+                }
+                sessions = sessions.filter(s => !evictIds.has(s.id));
+                if (activeSessionId && evictIds.has(activeSessionId)) {
+                    activeSessionId = sessions.length > 0 ? sessions[sessions.length - 1].id : null;
+                }
+            }
+
+            // Enforce total storage size limit — estimate and evict oldest if exceeded
+            let estimatedSize = 0;
+            const sessionsByAge = [...sessions].sort((a, b) => a.updatedAt - b.updatedAt);
+            for (const s of sessionsByAge) {
+                const nodeCount = this._loadedSessionIds.has(s.id) ? s.nodes.length : (s._nodeIds?.length || 0);
+                // Rough estimate: ~2KB per node average
+                estimatedSize += 200 + nodeCount * 2048;
+            }
+            while (estimatedSize > MAX_STORAGE_BYTES && sessions.length > 1) {
+                const oldest = sessionsByAge.shift()!;
+                if (oldest.id === activeSessionId) continue;
+                const nodeIds = this._loadedSessionIds.has(oldest.id)
+                    ? oldest.nodes.map(n => n.id)
+                    : (oldest._nodeIds || []);
+                if (nodeIds.length > 0) await this.deleteNodes(nodeIds);
+                this._loadedSessionIds.delete(oldest.id);
+                sessions = sessions.filter(s => s.id !== oldest.id);
+                const nodeCount = nodeIds.length;
+                estimatedSize -= 200 + nodeCount * 2048;
+            }
+
             const sessionMeta = sessions.map(s => ({
                 id: s.id,
                 title: s.title,

--- a/packages/app/src/stream-orchestrator.ts
+++ b/packages/app/src/stream-orchestrator.ts
@@ -17,12 +17,23 @@ export interface StreamCallbacks {
     onWorkflowTrace?: (steps: WorkflowStep[]) => void;
 }
 
+/** Maximum response size in characters (5 MB) */
+const MAX_RESPONSE_SIZE = 5 * 1024 * 1024;
+/** Default stream timeout in milliseconds (5 minutes) */
+const DEFAULT_STREAM_TIMEOUT_MS = 5 * 60 * 1000;
+
 export class StreamOrchestrator {
     private activeSource: EventSource | null = null;
     private cancelGeneration = 0;
+    private streamTimeoutMs = DEFAULT_STREAM_TIMEOUT_MS;
 
     get isStreaming(): boolean {
         return this.activeSource !== null;
+    }
+
+    /** Configure the stream timeout (in milliseconds). */
+    setStreamTimeout(ms: number): void {
+        this.streamTimeoutMs = Math.max(1000, ms);
     }
 
     cancel(): void {
@@ -82,25 +93,51 @@ export class StreamOrchestrator {
             const source = new EventSource(streamUrl);
             this.activeSource = source;
 
+            // Timeout: close stream if no 'done' event within the limit
+            let lastActivity = Date.now();
+            const timeoutCheck = setInterval(() => {
+                if (Date.now() - lastActivity > this.streamTimeoutMs) {
+                    clearInterval(timeoutCheck);
+                    source.close(); this.activeSource = null;
+                    if (fullText) { onDone(fullText); }
+                    else { onError('Stream timed out'); }
+                    resolve();
+                }
+            }, 5000);
+
+            const cleanup = () => {
+                clearInterval(timeoutCheck);
+                source.close();
+                this.activeSource = null;
+            };
+
             source.onmessage = (event) => {
+                lastActivity = Date.now();
                 if (this.cancelGeneration > myGeneration) return;
                 try {
                     const data = JSON.parse(event.data);
                     if (data.type === 'error') {
-                        source.close(); this.activeSource = null;
+                        cleanup();
                         onError(data.message || 'Unknown error');
                         resolve();
                     } else if (data.type === 'progress') {
                         if (onProgress) onProgress(data.stage, data.detail, data.meta);
                     } else if (data.type === 'content') {
                         fullText += data.text;
+                        // Enforce response size limit
+                        if (fullText.length > MAX_RESPONSE_SIZE) {
+                            cleanup();
+                            onError('Response size limit exceeded');
+                            resolve();
+                            return;
+                        }
                         onChunk(data.text, fullText);
                     } else if (data.type === 'workflow_trace') {
                         if (onWorkflowTrace) onWorkflowTrace(data.steps);
                     } else if (data.type === 'stats') {
                         if (onStats) onStats(data);
                     } else if (data.type === 'done') {
-                        source.close(); this.activeSource = null;
+                        cleanup();
                         onDone(fullText);
                         resolve();
                     }
@@ -108,7 +145,7 @@ export class StreamOrchestrator {
             };
 
             source.onerror = () => {
-                source.close(); this.activeSource = null;
+                cleanup();
                 if (this.cancelGeneration > myGeneration) { resolve(); }
                 else if (fullText) { onDone(fullText); resolve(); }
                 else { onError('Connection lost'); resolve(); }


### PR DESCRIPTION
## Summary
- **SRI hashes** on all 3 CDN script tags (Chart.js, DOMPurify, Marked) with `crossorigin="anonymous"`
- **DOMPurify hardening** with `FORBID_TAGS`/`FORBID_ATTR` and config passed to `renderMarkdown()`
- **Drill-down input sanitization** — strips control characters and truncates to 500 chars
- **Session store bounds** — max 100 sessions, ~10MB estimated limit, oldest-first eviction
- **Stream orchestrator** — 5-minute timeout, 5MB response size cap
- **Output transformer** — input type/size validation with 2MB cap

Part of #67

## Test plan
- [ ] `pnpm build` passes
- [ ] Load demo page — CDN scripts load without SRI errors in console
- [ ] Verify DOMPurify blocks `<script>`, `<iframe>`, and event handler attributes
- [ ] Confirm drill-down prompts sanitize special characters
- [ ] Create >100 sessions and verify oldest are evicted on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)