### PR TITLE
fix: add rate limiting to /api/title endpoint

### DIFF
--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -164,6 +164,14 @@ app.use('/api/chat/:id/stream', async (c, next) => {
     await next();
 });
 
+app.use('/api/title', async (c, next) => {
+    const ip = getClientIp(c.req.raw, c.req.raw.headers);
+    if (!checkRateLimit(ip)) {
+        return c.json({ error: 'Too many requests. Please try again later.' }, 429);
+    }
+    await next();
+});
+
 app.use('/api/lookup', async (c, next) => {
     const ip = getClientIp(c.req.raw, c.req.raw.headers);
     if (!checkRateLimit(ip)) {


### PR DESCRIPTION
## Summary
- Adds rate limit middleware to `/api/title` endpoint, matching the existing pattern used by `/api/chat`, `/api/chat/:id/stream`, and `/api/lookup`
- Prevents abuse of the LLM-backed title generation endpoint

Closes #75

## Test plan
- [ ] `pnpm build` passes
- [ ] Verify `/api/title` returns 429 when rate limit is exceeded
- [ ] Verify normal requests still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)