### PR TITLE
fix: return 400 for malformed request bodies

### DIFF
--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -176,7 +176,12 @@ app.use('/api/lookup', async (c, next) => {
 
 app.post('/api/chat', async (c) => {
     try {
-        const body = await c.req.json<{ prompt: string; conversationId?: string; model?: string }>();
+        let body: { prompt: string; conversationId?: string; model?: string };
+        try {
+            body = await c.req.json();
+        } catch {
+            return c.json({ error: 'Invalid request body' }, 400);
+        }
 
         // Validate prompt
         const promptErr = validatePrompt(body.prompt);
@@ -279,7 +284,13 @@ app.get('/api/servers', (c) => {
 
 app.post('/api/title', async (c) => {
     try {
-        const { prompt, response } = await c.req.json<{ prompt: string; response: string }>();
+        let body: { prompt: string; response: string };
+        try {
+            body = await c.req.json();
+        } catch {
+            return c.json({ error: 'Invalid request body' }, 400);
+        }
+        const { prompt, response } = body;
 
         // Validate prompt
         const promptErr = validatePrompt(prompt);
@@ -314,7 +325,13 @@ function evictLookupCache(): void {
 
 app.post('/api/lookup', async (c) => {
     try {
-        const { prompt } = await c.req.json<{ prompt: string }>();
+        let body: { prompt: string };
+        try {
+            body = await c.req.json();
+        } catch {
+            return c.json({ error: 'Invalid request body' }, 400);
+        }
+        const { prompt } = body;
 
         // Validate prompt
         const promptErr = validatePrompt(prompt);


### PR DESCRIPTION
## Summary
- Wraps `c.req.json()` in inner try/catch blocks for all three POST endpoints (`/api/chat`, `/api/title`, `/api/lookup`)
- Returns `400 { error: "Invalid request body" }` on JSON parse failure instead of falling through to the generic 500 handler
- Handles empty bodies, malformed JSON, and wrong Content-Type

Closes #74

## Test plan
- [ ] `curl -X POST http://localhost:3000/api/chat` (empty body) returns 400
- [ ] `curl -X POST http://localhost:3000/api/chat -d 'not json'` returns 400
- [ ] `curl -X POST http://localhost:3000/api/chat -H 'Content-Type: application/json' -d '{"prompt":"hello"}'` still works normally
- [ ] Same checks for `/api/title` and `/api/lookup`
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>