### PR TITLE
feat: replace MCP jargon with user-friendly language

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1553,7 +1553,7 @@ function getEmptyState() {
     return `
         <div class="burnish-empty-state">
             <h2>Burnish</h2>
-            <p>Your universal interface for MCP servers</p>
+            <p>Explore your data visually through connected services</p>
             <div class="burnish-server-buttons" id="server-buttons">
                 <div class="burnish-suggestion-skeleton-pill"></div>
                 <div class="burnish-suggestion-skeleton-pill"></div>

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -114,7 +114,7 @@
                         </svg>
                     </div>
                     <h2>Welcome to Burnish</h2>
-                    <p>Connect to any MCP server and explore your data visually.</p>
+                    <p>Explore your data visually through connected services.</p>
                     <div class="burnish-suggestions">
                         <button class="burnish-suggestion" data-prompt="What tools are available?">Available tools</button>
                         <button class="burnish-suggestion" data-prompt="Show me an overview of the data">Data overview</button>


### PR DESCRIPTION
## Summary
- Replace "Your universal interface for MCP servers" with "Explore your data visually through connected services" in the empty state (`app.js`)
- Replace "Connect to any MCP server and explore your data visually." with "Explore your data visually through connected services." in the static fallback (`index.html`)

Closes #77

## Test plan
- [ ] Run `pnpm dev` and verify the empty state shows the new tagline
- [ ] Hard-refresh to see the static fallback in `index.html` before JS loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)