### PR TITLE
feat: add visual feedback for empty prompt submission

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1195,7 +1195,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     // ── Submit handler ──
     async function handleSubmit(displayLabel) {
         const prompt = promptInput.value.trim();
-        if (!prompt) return;
+        if (!prompt) {
+            promptInput.classList.add('burnish-prompt-shake');
+            promptInput.setAttribute('placeholder', 'Type a message first...');
+            promptInput.addEventListener('animationend', () => {
+                promptInput.classList.remove('burnish-prompt-shake');
+                promptInput.setAttribute('placeholder', 'Ask about your data...');
+            }, { once: true });
+            return;
+        }
         promptInput.value = '';
         promptInput.style.height = '';
 

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1054,6 +1054,17 @@ body {
     .burnish-skeleton-grid { grid-template-columns: 1fr; }
 }
 
+/* ── Empty prompt shake ── */
+@keyframes promptShake {
+    0%, 100% { transform: translateX(0); }
+    20%, 60% { transform: translateX(-4px); }
+    40%, 80% { transform: translateX(4px); }
+}
+.burnish-prompt-container .burnish-prompt-input.burnish-prompt-shake {
+    animation: promptShake 0.4s ease-out;
+    border-color: var(--burnish-warning, #eab308);
+}
+
 @media (max-width: 480px) {
     .burnish-empty-state { padding: 40px 16px 40px; }
     .burnish-empty-state h2 { font-size: 22px; }


### PR DESCRIPTION
## Summary
- Adds a shake animation and temporary placeholder change when the user submits an empty prompt, replacing the previous silent no-op behavior
- CSS `@keyframes promptShake` animation with warning border color provides clear visual feedback

Closes #78

## Test plan
- [ ] Open the demo app and press Enter or click Send with an empty prompt input
- [ ] Verify the input shakes briefly and the placeholder changes to "Type a message first..."
- [ ] Verify after 1.5s the placeholder reverts to "Ask about your data..."
- [ ] Verify normal prompt submission still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)