### PR TITLE
feat: improve mobile and tablet responsive layout

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1043,10 +1043,22 @@ body {
 }
 
 /* ── Responsive ── */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     .burnish-session-panel { left: -260px; transition: left var(--burnish-transition-normal); }
     .burnish-session-panel.open { left: 0; }
     .burnish-content { margin-left: 0; }
     .burnish-mobile-only { display: flex; }
+}
+
+@media (max-width: 768px) {
     .burnish-skeleton-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 480px) {
+    .burnish-empty-state { padding: 40px 16px 40px; }
+    .burnish-empty-state h2 { font-size: 22px; }
+    .burnish-server-buttons { flex-direction: column; align-items: center; }
+    .burnish-tool-shortcuts { flex-direction: column; align-items: center; }
+    .burnish-prompt-bar { padding: 0 12px; }
+    .burnish-prompt-container { max-width: 100%; }
 }


### PR DESCRIPTION
## Summary
- Add 1024px tablet breakpoint to collapse session panel and remove content margin on medium screens
- Add 480px small phone breakpoint for compact empty state, stacked buttons, and tighter prompt bar
- Narrow existing 768px breakpoint to skeleton-grid-only

Closes #79

## Test plan
- [ ] Verify session panel collapses at 1024px and below
- [ ] Verify skeleton grid switches to single column at 768px
- [ ] Verify empty state, server buttons, and prompt bar adapt at 480px
- [ ] Confirm no visual regressions on desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)