### PR TITLE
feat: add Streamable HTTP transport for remote MCP servers

### DIFF
--- a/packages/server/src/mcp-hub.ts
+++ b/packages/server/src/mcp-hub.ts
@@ -76,6 +76,9 @@ export class McpHub {
         let transport: StdioClientTransport | StreamableHTTPClientTransport;
         if (config.url) {
             // Streamable HTTP transport for remote servers
+            // TRUST: headers come from the local mcp-servers.json config file,
+            // not from user input. If config is ever sourced from untrusted input,
+            // headers must be validated to prevent SSRF.
             const opts: { requestInit?: RequestInit } = {};
             if (config.headers) {
                 opts.requestInit = { headers: config.headers };


### PR DESCRIPTION
## Summary
- Extends `McpHub` to support both stdio (local) and Streamable HTTP (remote) MCP server transports
- Auto-detects transport type from config: `command` field triggers stdio, `url` field triggers HTTP
- Optional `headers` field supports auth tokens for remote servers

## Config example
```json
{
  "mcpServers": {
    "local-fs": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home"] },
    "remote-api": { "url": "https://mcp.example.com/api", "headers": { "Authorization": "Bearer token" } }
  }
}
```

## Test plan
- [ ] Build passes (`pnpm build`)
- [ ] Existing stdio servers still connect correctly
- [ ] Remote HTTP server connects with `url` config
- [ ] Auth headers are passed through to HTTP transport
- [ ] Config with neither `command` nor `url` throws descriptive error

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>