### PR TITLE
chore: local model developer experience improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# LLM Backend (choose one)
+# LLM_BACKEND=cli          # Claude Code CLI (default, no key needed)
+# LLM_BACKEND=api          # Anthropic API (requires ANTHROPIC_API_KEY)
+# LLM_BACKEND=openai       # OpenAI-compatible (Ollama, llama.cpp, vLLM)
+
+# Anthropic API
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI-compatible / Local models
+# OPENAI_API_KEY=sk-...                          # Optional for local servers
+# OPENAI_BASE_URL=http://localhost:11434/v1       # Ollama default
+# OPENAI_MODEL=qwen2.5:7b                         # Recommended model
+
+# MCP Server Config
+# GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...            # For GitHub MCP server
+
+# Security (optional)
+# BURNISH_API_KEY=your-secret                     # Require Bearer token auth
+# TRUST_PROXY=true                                # Trust X-Forwarded-For for rate limiting

--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ pnpm dev:cli
 
 # Option 2: Use direct Anthropic API key
 ANTHROPIC_API_KEY=sk-ant-... pnpm dev
+
+# Option 3: Use local model via Ollama (no API key needed)
+ollama pull qwen2.5:7b
+pnpm dev:local
 ```
 
 The demo app starts at `http://localhost:3000`. Configure your MCP servers in `apps/demo/mcp-servers.json`, then ask a question.
+
+### Local Model Support
+
+Burnish supports local models via any OpenAI-compatible API (Ollama, llama.cpp, vLLM, LM Studio). The `dev:local` script is pre-configured for Ollama with Qwen 2.5 7B, which offers the best balance of tool-calling reliability and component output quality. Other tested models include Llama 3.1 8B (highest component accuracy) and Llama 3.2 3B (lowest resource usage). See `CLAUDE.md` for the full benchmark table.
 
 ### Prerequisites
 
@@ -196,11 +204,12 @@ const prompt = buildSystemPrompt('Your additional domain-specific instructions h
 
 ### LLM Backend
 
-| Mode | Env Var                        | Description                                                           |
-|------|--------------------------------|-----------------------------------------------------------------------|
-| API  | `ANTHROPIC_API_KEY=sk-ant-...` | Direct Anthropic SDK with streaming tool-call loop (5 rounds max)     |
-| CLI  | `LLM_BACKEND=cli`              | Spawns Claude CLI subprocess; uses your Claude Code subscription auth |
-| Auto | *(none)*                       | Defaults to CLI if no API key is set                                  |
+| Mode   | Env Var                        | Description                                                             |
+|--------|--------------------------------|-------------------------------------------------------------------------|
+| API    | `ANTHROPIC_API_KEY=sk-ant-...` | Direct Anthropic SDK with streaming tool-call loop (8 rounds max)       |
+| CLI    | `LLM_BACKEND=cli`              | Spawns Claude CLI subprocess; uses your Claude Code subscription auth   |
+| OpenAI | `LLM_BACKEND=openai`           | OpenAI-compatible API (Ollama, llama.cpp, vLLM, LM Studio, OpenAI)     |
+| Auto   | *(none)*                        | Defaults to CLI if no API key is set                                    |
 
 ### MCP Servers
 
@@ -217,7 +226,7 @@ Configure connected MCP servers in `apps/demo/mcp-servers.json`:
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   }

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx watch server/index.ts",
     "dev:cli": "cross-env LLM_BACKEND=cli tsx watch server/index.ts",
+    "dev:local": "cross-env LLM_BACKEND=openai OPENAI_BASE_URL=http://localhost:11434/v1 OPENAI_MODEL=qwen2.5:7b tsx watch server/index.ts",
     "build": "echo 'demo app - no build step'",
     "clean": "echo 'nothing to clean'"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "pnpm -r build",
     "dev": "pnpm --filter demo dev",
     "dev:cli": "pnpm --filter demo dev:cli",
+    "dev:local": "pnpm --filter demo dev:local",
     "clean": "pnpm -r clean",
     "prepare": "git config core.hooksPath .githooks"
   },


### PR DESCRIPTION
## Summary
- Add `dev:local` script (root + demo) pre-configured for Ollama with Qwen 2.5 7B
- Update README with local model quick start (Option 3), Local Model Support section, and OpenAI backend in LLM Backend table
- Replace hardcoded GitHub token in README config example with `${GITHUB_PERSONAL_ACCESS_TOKEN}` env var template
- Create `.env.example` documenting all supported environment variables

Closes #92

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm dev:local` starts the demo app with Ollama backend (requires Ollama running locally)
- [ ] `.env.example` contains all documented env vars
- [ ] README accurately reflects all three LLM backend options

🤖 Generated with [Claude Code](https://claude.com/claude-code)