### PR TITLE
feat: replace Fast mode toggle with model selector dropdown

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -41,7 +41,7 @@ const ICON_REFRESH = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none
 const SAFE_ATTRS = new Set(PURIFY_CONFIG.ADD_ATTR);
 
 // ── State ──
-let fastMode = localStorage.getItem('burnish:fastMode') === 'true';
+let selectedModel = localStorage.getItem('burnish:selectedModel') || '';
 let searchQuery = '';
 let searchDebounceTimer = null;
 let dashboardMode = localStorage.getItem('burnish:dashboardMode') === 'true';
@@ -978,14 +978,29 @@ document.addEventListener('DOMContentLoaded', async () => {
     const container = document.getElementById('dashboard-container');
     const breadcrumb = document.getElementById('breadcrumb');
 
-    // ── Fast mode toggle ──
-    const fastToggle = document.getElementById('fast-toggle');
-    if (fastToggle) {
-        if (fastMode) fastToggle.classList.add('active');
-        fastToggle.addEventListener('click', () => {
-            fastMode = !fastMode;
-            fastToggle.classList.toggle('active', fastMode);
-            localStorage.setItem('burnish:fastMode', String(fastMode));
+    // ── Model selector ──
+    const modelSelect = document.getElementById('model-select');
+    if (modelSelect) {
+        fetch('/api/models')
+            .then(r => r.json())
+            .then(({ models, current }) => {
+                if (models.length === 0) {
+                    modelSelect.innerHTML = '<option value="">No models</option>';
+                    return;
+                }
+                const activeModel = selectedModel || current;
+                modelSelect.innerHTML = models.map(m =>
+                    `<option value="${escapeAttr(m.id)}"${m.id === activeModel ? ' selected' : ''}>${escapeHtml(m.name)}</option>`
+                ).join('');
+                if (!selectedModel) selectedModel = current;
+            })
+            .catch(() => {
+                modelSelect.innerHTML = '<option value="">Default</option>';
+            });
+
+        modelSelect.addEventListener('change', () => {
+            selectedModel = modelSelect.value;
+            localStorage.setItem('burnish:selectedModel', selectedModel);
         });
     }
 
@@ -1595,7 +1610,7 @@ function submitPrompt(prompt, existingConversationId, onChunk, onDone, onError, 
         '', // same origin
         prompt,
         existingConversationId,
-        fastMode ? 'haiku' : undefined,
+        selectedModel || undefined,
         { onChunk, onDone, onError, onProgress, onStats, onWorkflowTrace },
     ).catch(onError);
 }

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -95,10 +95,9 @@
                     <rect x="10" y="10" width="7" height="7" rx="1"/>
                 </svg>
             </button>
-            <div id="fast-toggle" class="burnish-fast-toggle" title="Use faster model (Haiku)">
-                <span>Fast</span>
-                <div class="burnish-fast-toggle-switch"></div>
-            </div>
+            <select id="model-select" class="burnish-model-select" title="Select model">
+                <option value="">Loading...</option>
+            </select>
         </div>
     </header>
 

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -449,44 +449,34 @@ body {
     to { opacity: 1; transform: translateY(0); }
 }
 
-/* ── Fast mode toggle ── */
-.burnish-fast-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+/* ── Model Selector ── */
+.burnish-model-select {
+    background: rgba(255,255,255,0.1);
+    color: rgba(255,255,255,0.9);
+    border: 1px solid rgba(255,255,255,0.2);
+    border-radius: 4px;
+    padding: 4px 24px 4px 8px;
     font-size: 11px;
-    color: rgba(255,255,255,0.6);
+    font-family: inherit;
     cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    transition: all var(--burnish-transition-fast);
-    user-select: none;
+    outline: none;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='rgba(255,255,255,0.6)' fill='none' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    min-width: 100px;
 }
-.burnish-fast-toggle:hover { color: white; background: rgba(255,255,255,0.1); }
-.burnish-fast-toggle-switch {
-    width: 28px;
-    height: 16px;
-    background: rgba(255,255,255,0.2);
-    border-radius: 4px;
-    position: relative;
-    transition: background 0.2s ease;
+.burnish-model-select:hover {
+    background-color: rgba(255,255,255,0.15);
+    border-color: rgba(255,255,255,0.3);
 }
-.burnish-fast-toggle-switch::after {
-    content: '';
-    width: 12px;
-    height: 12px;
-    background: white;
-    border-radius: 50%;
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    transition: transform 0.2s ease;
+.burnish-model-select:focus {
+    border-color: var(--burnish-accent, #4f6df5);
 }
-.burnish-fast-toggle.active .burnish-fast-toggle-switch {
-    background: var(--burnish-success, #22c55e);
-}
-.burnish-fast-toggle.active .burnish-fast-toggle-switch::after {
-    transform: translateX(12px);
+.burnish-model-select option {
+    background: #1a1a2e;
+    color: white;
 }
 
 /* ── Text Response (Markdown) ── */

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -43,6 +43,9 @@ const mcpHub = new McpHub();
 const conversations = new ConversationStore(1000);
 const llm = new LlmOrchestrator(mcpHub, conversations);
 
+let activeModelName = 'sonnet'; // Set during start()
+let activeBackend = 'cli';
+
 // --- Validation helpers ---
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -318,6 +321,32 @@ app.get('/api/servers', (c) => {
     }
 });
 
+app.get('/api/models', async (c) => {
+    let available: { id: string; name: string }[] = [];
+
+    if (activeBackend === 'openai') {
+        try {
+            const baseUrl = (process.env.OPENAI_BASE_URL || 'http://localhost:11434/v1').replace('/v1', '');
+            const resp = await fetch(baseUrl + '/api/tags');
+            if (resp.ok) {
+                const data = await resp.json() as { models?: { name: string }[] };
+                available = (data.models || []).map((m) => ({
+                    id: m.name,
+                    name: m.name,
+                }));
+            }
+        } catch { /* Ollama not reachable */ }
+    } else {
+        available = [
+            { id: 'sonnet', name: 'Sonnet' },
+            { id: 'haiku', name: 'Haiku (Fast)' },
+            { id: 'opus', name: 'Opus (Detailed)' },
+        ];
+    }
+
+    return c.json({ models: available, current: activeModelName, backend: activeBackend });
+});
+
 app.post('/api/title', async (c) => {
     try {
         let body: { prompt: string; response: string };
@@ -529,6 +558,9 @@ async function start() {
             console.warn('[burnish] Then pull a model: ollama pull ' + modelName);
         }
     }
+
+    activeModelName = modelName;
+    activeBackend = llmBackend;
 
     llm.configure({
         backend: llmBackend,


### PR DESCRIPTION
## Summary
- Replace the hardcoded Fast/Haiku toggle with a dynamic `<select>` dropdown in the header
- Add `GET /api/models` endpoint that returns available models (Ollama: fetches from `/api/tags`; Anthropic: Sonnet/Haiku/Opus)
- Persist selected model in localStorage across sessions

## Test plan
- [ ] `pnpm build` passes
- [ ] Dropdown populates with Sonnet/Haiku/Opus for Anthropic backends
- [ ] Dropdown populates with Ollama model names when using `LLM_BACKEND=openai`
- [ ] Selected model is sent with chat requests instead of hardcoded haiku
- [ ] Selection persists across page reloads via localStorage

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>