### PR TITLE
fix: scope server button prompts to correct tool set

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1686,12 +1686,17 @@ async function loadDynamicSuggestions(container) {
             if (servers.length === 0) {
                 serverBtns.innerHTML = '<span class="burnish-no-servers">No servers connected</span>';
             } else {
-                serverBtns.innerHTML = servers.map(s => `
-                    <button class="burnish-suggestion burnish-suggestion-server" data-prompt="${escapeAttr(`Show me what I can do with the connected ${s.name} tools. List the available operations as cards.`)}" data-label="${escapeAttr(s.name)}">
+                serverBtns.innerHTML = servers.map(s => {
+                    const toolList = s.tools.slice(0, 15).map(t => t.name).join(', ');
+                    const moreText = s.tools.length > 15 ? ` and ${s.tools.length - 15} more` : '';
+                    const prompt = `Show me what I can do with the ${s.name} server. Available tools: ${toolList}${moreText}. List each tool as a burnish-card. Use ONLY the tools listed above.`;
+                    return `
+                    <button class="burnish-suggestion burnish-suggestion-server" data-prompt="${escapeAttr(prompt)}" data-label="${escapeAttr(s.name)}">
                         ${escapeHtml(s.name)}
                         <span class="burnish-suggestion-sub">${s.toolCount} tools</span>
                     </button>
-                `).join('');
+                `;
+                }).join('');
             }
         }
 


### PR DESCRIPTION
## Summary
- Server button prompts now include the actual tool names from that server, preventing smaller models from picking tools from the wrong server
- Truncates to 15 tools with "and N more" suffix for servers with large tool sets

Closes #99

## Test plan
- [ ] Click a server button and verify the prompt includes the server's tool names
- [ ] With multiple servers connected, verify each button lists only its own tools
- [ ] Test with a server that has >15 tools to verify truncation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)