### PR TITLE
fix: suppress preamble text during streaming

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -447,7 +447,10 @@ async function regenerateNode(nodeId) {
                     contentEl.innerHTML = '';
                     node.type = 'components';
                 }
-                const elements = findStreamElements(trimmed);
+                // Strip any preamble text before the first burnish tag
+                const componentStart = trimmed.indexOf('<burnish-');
+                const componentHtml = componentStart > 0 ? trimmed.substring(componentStart) : trimmed;
+                const elements = findStreamElements(componentHtml);
                 while (renderedCount < elements.length) {
                     const el = elements[renderedCount];
                     appendElement(contentEl, containerStack, el);
@@ -457,9 +460,9 @@ async function regenerateNode(nodeId) {
                     }
                     renderedCount++;
                 }
-            } else {
-                contentEl.innerHTML = `<div class="burnish-text-response burnish-streaming">${renderMarkdown(trimmed)}</div>`;
             }
+            // Don't render plain text during streaming — buffer it.
+            // If the stream ends without burnish tags, onDone renders it as text.
         },
         async (fullText, newConversationId) => {
             stopProgressTimer();
@@ -1409,7 +1412,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                         contentEl.innerHTML = '';
                         node.type = 'components';
                     }
-                    const elements = findStreamElements(trimmed);
+                    // Strip any preamble text before the first burnish tag
+                    const componentStart = trimmed.indexOf('<burnish-');
+                    const componentHtml = componentStart > 0 ? trimmed.substring(componentStart) : trimmed;
+                    const elements = findStreamElements(componentHtml);
                     while (renderedCount < elements.length) {
                         const el = elements[renderedCount];
                         appendElement(contentEl, containerStack, el);
@@ -1419,9 +1425,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                         }
                         renderedCount++;
                     }
-                } else {
-                    contentEl.innerHTML = `<div class="burnish-text-response burnish-streaming">${renderMarkdown(trimmed)}</div>`;
                 }
+                // Don't render plain text during streaming — buffer it.
+                // If the stream ends without burnish tags, onDone renders it as text.
             },
             // onDone
             async (fullText, newConversationId) => {


### PR DESCRIPTION
## Summary
- Buffer plain text during streaming instead of rendering it immediately -- preamble like "Sure, let's outline..." from local models is no longer visible
- Once a `<burnish-` tag is detected, strip everything before it and begin rendering components only
- If the stream ends without burnish tags, `onDone` still renders the full text as markdown (no behavior change for text-only responses)

Closes #98

## Test plan
- [ ] Run with a local model (e.g. Ollama + Qwen) that outputs preamble before burnish components
- [ ] Verify preamble text is not visible during streaming -- spinner/progress state remains until components appear
- [ ] Verify components render correctly once they start streaming
- [ ] Verify pure text responses (no burnish tags) still render correctly on stream completion
- [ ] Verify drill-down streaming (second onChunk path) also suppresses preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)