### PR TITLE
fix: prevent local model mass tool calling and guard write tools

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1695,7 +1695,7 @@ async function loadDynamicSuggestions(container) {
                 serverBtns.innerHTML = servers.map(s => {
                     const toolList = s.tools.slice(0, 15).map(t => t.name).join(', ');
                     const moreText = s.tools.length > 15 ? ` and ${s.tools.length - 15} more` : '';
-                    const prompt = `Show me what I can do with the ${s.name} server. Available tools: ${toolList}${moreText}. List each tool as a burnish-card. Use ONLY the tools listed above.`;
+                    const prompt = `You have access to a ${s.name} server with these operations: ${toolList}${moreText}. Generate a burnish-card for each operation showing its name and a brief description. Do NOT call any tools. Just output burnish-card HTML components describing what each operation does.`;
                     return `
                     <button class="burnish-suggestion burnish-suggestion-server" data-prompt="${escapeAttr(prompt)}" data-label="${escapeAttr(s.name)}">
                         ${escapeHtml(s.name)}

--- a/packages/server/src/llm.ts
+++ b/packages/server/src/llm.ts
@@ -17,6 +17,7 @@ import { createInterface } from 'node:readline';
 import type { McpHub } from './mcp-hub.js';
 import type { ConversationStore, Conversation } from './conversation.js';
 import { buildSystemPrompt } from './prompt-template.js';
+import { isWriteTool } from './guards.js';
 
 export interface WorkflowStep {
     server: string;
@@ -622,15 +623,22 @@ export class LlmOrchestrator {
 
                 let resultContent: string;
                 try {
-                    yield { type: 'progress', stage: 'tool_call', detail: `Calling ${tc.name}…`, meta: { server } };
-                    console.log(`[llm-openai] Executing tool: ${tc.name}`);
+                    // Block write tools from being auto-called by the model
+                    if (isWriteTool(tc.name)) {
+                        console.log(`[llm-openai] Blocked write tool: ${tc.name}`);
+                        step.status = 'error';
+                        resultContent = `Tool "${tc.name}" is a write operation and requires user confirmation. Generate a burnish-form component instead so the user can review and submit.`;
+                    } else {
+                        yield { type: 'progress', stage: 'tool_call', detail: `Calling ${tc.name}…`, meta: { server } };
+                        console.log(`[llm-openai] Executing tool: ${tc.name}`);
 
-                    let args: Record<string, unknown> = {};
-                    try { args = JSON.parse(tc.arguments || '{}'); } catch { console.warn('[llm-openai] Failed to parse tool call arguments:', tc.arguments); }
+                        let args: Record<string, unknown> = {};
+                        try { args = JSON.parse(tc.arguments || '{}'); } catch { console.warn('[llm-openai] Failed to parse tool call arguments:', tc.arguments); }
 
-                    const result = await this.mcpHub.executeTool(tc.name, args);
-                    step.status = 'success';
-                    resultContent = typeof result === 'string' ? result : JSON.stringify(result);
+                        const result = await this.mcpHub.executeTool(tc.name, args);
+                        step.status = 'success';
+                        resultContent = typeof result === 'string' ? result : JSON.stringify(result);
+                    }
                 } catch (err) {
                     step.status = 'error';
                     resultContent = `Error: ${err instanceof Error ? err.message : String(err)}`;


### PR DESCRIPTION
## Summary
- Reword server button prompt to use "operations" instead of "tools" and explicitly say "Do NOT call any tools", preventing local models (Qwen 2.5 7B) from mass-invoking every tool
- Add write-tool guard in the OpenAI backend's tool execution loop using `isWriteTool()` from guards.ts, blocking write operations (create, update, delete, push, etc.) unless submitted through a burnish-form by the user

## Test plan
- [ ] Start Burnish with Qwen 2.5 7B via Ollama (`LLM_BACKEND=openai`)
- [ ] Click a server button and verify the model outputs burnish-card HTML instead of calling tools
- [ ] Verify write tools (e.g. `create_or_update_file`) are blocked with a message directing to burnish-form
- [ ] Verify read tools still execute normally
- [ ] `pnpm build` passes

Closes #102

Generated with [Claude Code](https://claude.com/claude-code)