### PR TITLE
fix: omit tools from overview prompts to prevent mass tool calling

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1093,7 +1093,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const btn = e.target.closest('.burnish-suggestion');
         if (btn?.dataset.prompt) {
             promptInput.value = btn.dataset.prompt;
-            handleSubmit(btn.dataset.label || undefined);
+            const noTools = btn.dataset.noTools === 'true';
+            handleSubmit(btn.dataset.label || undefined, noTools);
         }
     });
 
@@ -1289,7 +1290,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     // ── Submit handler ──
-    async function handleSubmit(displayLabel) {
+    async function handleSubmit(displayLabel, noTools) {
         const prompt = promptInput.value.trim();
         if (!prompt) {
             promptInput.classList.add('burnish-prompt-shake');
@@ -1566,7 +1567,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             // onWorkflowTrace
             (steps) => {
                 updateWorkflowTrace(contentEl, steps);
-            }
+            },
+            noTools
         );
 
         promptInput.disabled = true;
@@ -1611,13 +1613,14 @@ function updateWorkflowTrace(contentEl, steps) {
 
 // ── SSE Streaming (via StreamOrchestrator) ──
 
-function submitPrompt(prompt, existingConversationId, onChunk, onDone, onError, onProgress, onStats, onWorkflowTrace) {
+function submitPrompt(prompt, existingConversationId, onChunk, onDone, onError, onProgress, onStats, onWorkflowTrace, noTools) {
     streamOrchestrator.submitPrompt(
         '', // same origin
         prompt,
         existingConversationId,
         selectedModel || undefined,
         { onChunk, onDone, onError, onProgress, onStats, onWorkflowTrace },
+        noTools,
     ).catch(onError);
 }
 
@@ -1697,7 +1700,7 @@ async function loadDynamicSuggestions(container) {
                     const moreText = s.tools.length > 15 ? ` and ${s.tools.length - 15} more` : '';
                     const prompt = `You have access to a ${s.name} server with these operations: ${toolList}${moreText}. Generate a burnish-card for each operation showing its name and a brief description. Do NOT call any tools. Just output burnish-card HTML components describing what each operation does.`;
                     return `
-                    <button class="burnish-suggestion burnish-suggestion-server" data-prompt="${escapeAttr(prompt)}" data-label="${escapeAttr(s.name)}">
+                    <button class="burnish-suggestion burnish-suggestion-server" data-prompt="${escapeAttr(prompt)}" data-label="${escapeAttr(s.name)}" data-no-tools="true">
                         ${escapeHtml(s.name)}
                         <span class="burnish-suggestion-sub">${s.toolCount} tools</span>
                     </button>

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -206,7 +206,7 @@ app.use('/api/lookup', async (c, next) => {
 
 app.post('/api/chat', async (c) => {
     try {
-        let body: { prompt: string; conversationId?: string; model?: string };
+        let body: { prompt: string; conversationId?: string; model?: string; noTools?: boolean };
         try {
             body = await c.req.json();
         } catch {
@@ -230,9 +230,10 @@ app.post('/api/chat', async (c) => {
         const conv = conversations.getOrCreate(body.conversationId);
         conversations.addMessage(conv.id, 'user', body.prompt);
         const modelParam = body.model ? `?model=${encodeURIComponent(body.model)}` : '';
+        const noToolsParam = body.noTools ? `${modelParam ? '&' : '?'}noTools=true` : '';
         return c.json({
             conversationId: conv.id,
-            streamUrl: `/api/chat/${conv.id}/stream${modelParam}`,
+            streamUrl: `/api/chat/${conv.id}/stream${modelParam}${noToolsParam}`,
         });
     } catch (err) {
         console.error('[burnish] POST /api/chat error:', err);
@@ -254,12 +255,13 @@ app.get('/api/chat/:id/stream', async (c) => {
             const modelErr = validateModel(requestModel);
             if (modelErr) return c.json({ error: modelErr }, 400);
         }
+        const noTools = c.req.query('noTools') === 'true';
 
         const stream = new ReadableStream({
             async start(controller) {
                 const encoder = new TextEncoder();
                 try {
-                    for await (const chunk of llm.streamResponse(id, requestModel)) {
+                    for await (const chunk of llm.streamResponse(id, requestModel, noTools)) {
                         const data = JSON.stringify(chunk);
                         controller.enqueue(encoder.encode(`data: ${data}\n\n`));
                     }

--- a/packages/app/src/stream-orchestrator.ts
+++ b/packages/app/src/stream-orchestrator.ts
@@ -53,12 +53,13 @@ export class StreamOrchestrator {
         conversationId: string | null,
         model: string | undefined,
         callbacks: StreamCallbacks,
+        noTools?: boolean,
     ): Promise<void> {
         try {
             const res = await fetch(`${apiBase}/api/chat`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ prompt, conversationId, model }),
+                body: JSON.stringify({ prompt, conversationId, model, noTools }),
             });
             if (!res.ok) throw new Error(`API error: ${res.status}`);
             const data = await res.json();

--- a/packages/server/src/llm.ts
+++ b/packages/server/src/llm.ts
@@ -126,6 +126,7 @@ export class LlmOrchestrator {
     async *streamResponse(
         conversationId: string,
         requestModel?: string,
+        noTools?: boolean,
     ): AsyncGenerator<StreamChunk> {
         // For openai backend, allow any model; for others, validate against allowlist
         if (requestModel && this.backend !== 'openai' && !ALLOWED_MODELS.has(requestModel)) {
@@ -133,11 +134,11 @@ export class LlmOrchestrator {
         }
         const useModel = requestModel || this.model;
         if (this.backend === 'cli') {
-            yield* this.streamResponseCli(conversationId, useModel);
+            yield* this.streamResponseCli(conversationId, useModel, noTools);
         } else if (this.backend === 'openai') {
-            yield* this.streamResponseOpenai(conversationId, useModel);
+            yield* this.streamResponseOpenai(conversationId, useModel, noTools);
         } else {
-            yield* this.streamResponseApi(conversationId, useModel);
+            yield* this.streamResponseApi(conversationId, useModel, noTools);
         }
     }
 
@@ -148,6 +149,7 @@ export class LlmOrchestrator {
     private async *streamResponseCli(
         conversationId: string,
         useModel = this.model,
+        noTools?: boolean,
     ): AsyncGenerator<StreamChunk> {
         const conv = this.conversations.get(conversationId);
         if (!conv) return;
@@ -165,7 +167,7 @@ export class LlmOrchestrator {
 
             // Build allowed tools list from connected MCP servers
             const mcpTools = this.mcpHub.getAllTools();
-            const allowedToolNames = mcpTools.map(t => `mcp__${t.serverName}__${t.name}`);
+            const allowedToolNames = noTools ? [] : mcpTools.map(t => `mcp__${t.serverName}__${t.name}`);
 
             const mcpConfigPath = this.mcpConfigPath;
             if (!mcpConfigPath) throw new Error('mcpConfigPath required for CLI backend');
@@ -177,8 +179,8 @@ export class LlmOrchestrator {
                 '--include-partial-messages',
                 '--model', useModel,
                 '--system-prompt-file', tempFile,
-                '--mcp-config', mcpConfigPath,
-                '--strict-mcp-config',
+                // Only include MCP config and tools when tools are not explicitly disabled
+                ...(noTools ? [] : ['--mcp-config', mcpConfigPath, '--strict-mcp-config']),
                 '--tools', '',
                 '--setting-sources', 'user',
                 ...(allowedToolNames.length > 0
@@ -330,6 +332,7 @@ export class LlmOrchestrator {
     private async *streamResponseApi(
         conversationId: string,
         useModel = this.model,
+        noTools?: boolean,
     ): AsyncGenerator<StreamChunk> {
         if (!this.client) throw new Error('LLM not configured — call configure() first');
 
@@ -347,7 +350,7 @@ export class LlmOrchestrator {
             return { role: m.role, content: m.content };
         });
 
-        const mcpTools = this.mcpHub.getAllTools();
+        const mcpTools = noTools ? [] : this.mcpHub.getAllTools();
         const tools: Anthropic.Tool[] = mcpTools.map((t, i) => ({
             name: t.name,
             description: t.description,
@@ -500,6 +503,7 @@ export class LlmOrchestrator {
     private async *streamResponseOpenai(
         conversationId: string,
         useModel = this.model,
+        noTools?: boolean,
     ): AsyncGenerator<StreamChunk> {
         if (!this.openaiClient) throw new Error('OpenAI client not configured — call configure() first');
 
@@ -522,7 +526,7 @@ export class LlmOrchestrator {
         }
 
         // Convert MCP tools to OpenAI function calling format
-        const mcpTools = this.mcpHub.getAllTools();
+        const mcpTools = noTools ? [] : this.mcpHub.getAllTools();
         const tools: OpenAI.ChatCompletionTool[] = mcpTools.map(t => ({
             type: 'function' as const,
             function: {

--- a/tests/no-tools-overview.spec.ts
+++ b/tests/no-tools-overview.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test('server overview button generates cards without calling tools', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for server buttons to load
+    await page.waitForSelector('.burnish-suggestion-server');
+
+    // Verify server buttons have data-no-tools attribute
+    const noToolsAttr = await page.locator('.burnish-suggestion-server').first().getAttribute('data-no-tools');
+    expect(noToolsAttr).toBe('true');
+
+    // Click a server button (prefer filesystem — fewer tools, faster)
+    const fsButton = page.locator('.burnish-suggestion-server', { hasText: 'filesystem' });
+    if (await fsButton.count() > 0) {
+        await fsButton.click();
+    } else {
+        // Click whatever server button exists
+        await page.locator('.burnish-suggestion-server').first().click();
+    }
+
+    // Wait for response to complete
+    await page.waitForFunction(() => {
+        const btn = document.getElementById('btn-submit');
+        return btn && !btn.classList.contains('cancel');
+    }, { timeout: 120_000 });
+
+    // Should have at least one node rendered
+    const nodeCount = await page.locator('.burnish-node').count();
+    expect(nodeCount).toBeGreaterThanOrEqual(1);
+
+    // Should NOT have "No response received" (which means tool loop exhausted)
+    const content = await page.locator('.burnish-node-content').first().textContent();
+    expect(content).not.toContain('No response received');
+});


### PR DESCRIPTION
## Summary
- Adds a `noTools` flag that flows from frontend server-overview buttons through the API to the LLM orchestrator
- When `noTools=true`, tools are omitted entirely from the API request (OpenAI, Anthropic, and CLI backends)
- Server overview buttons (`data-no-tools="true"`) now produce descriptive burnish-card HTML without triggering tool calls

Closes #102

## Test plan
- [ ] Click a server overview button with Qwen 2.5 7B -- should render burnish-cards without tool-call loops
- [ ] Click a server overview button with Anthropic backend -- should still work (no tools passed)
- [ ] Regular prompts (without noTools) should still call tools normally
- [ ] `pnpm build` passes
- [ ] Playwright test: `npx playwright test tests/no-tools-overview.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)