### PR TITLE
feat: rule-based response quality scoring

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -10,6 +10,7 @@ import {
     isWriteTool, getDrillDownPrompt, generateFallbackForm,
     StreamOrchestrator,
     generateSummary, formatTimeAgo,
+    scoreResponse,
 } from '@burnish/app';
 import {
     findStreamElements, appendStreamElement, extractHtmlContent, containsTags as containsBurnishTags,
@@ -477,6 +478,10 @@ async function regenerateNode(nodeId) {
             node.response = trimmed;
             node.type = containsBurnishTags(trimmed) ? 'components' : 'text';
 
+            // Score the response quality
+            const score = scoreResponse(node.response || '');
+            node._qualityScore = score.total;
+
             if (!trimmed) {
                 contentEl.innerHTML = '<div class="burnish-text-response" style="color: var(--burnish-text-muted, #9ca3af); font-style: italic;">No response received. Try regenerating.</div>';
                 node.type = 'text';
@@ -756,6 +761,11 @@ function toggleDiagnosticPanel(nodeId) {
         if (node.stats.costUsd) {
             metrics.push(`<span class="burnish-diag-metric"><strong>Cost</strong> $${node.stats.costUsd.toFixed(4)}</span>`);
         }
+    }
+
+    // Quality score
+    if (node._qualityScore != null) {
+        metrics.push(`<span class="burnish-diag-metric"><strong>Quality</strong> ${node._qualityScore}/10</span>`);
     }
 
     // Extract model from progress log
@@ -1445,6 +1455,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const trimmed = fullText.trim();
                 node.response = trimmed;
                 node.type = containsBurnishTags(trimmed) ? 'components' : 'text';
+
+                // Score the response quality
+                const score = scoreResponse(node.response || '');
+                node._qualityScore = score.total;
 
                 if (!trimmed) {
                     contentEl.innerHTML = '<div class="burnish-text-response" style="color: var(--burnish-text-muted, #9ca3af); font-style: italic;">No response received. Try regenerating.</div>';

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -39,3 +39,8 @@ export {
     generateSummary,
     formatTimeAgo,
 } from './summary.js';
+
+export {
+    scoreResponse,
+    type QualityScore,
+} from './quality-scorer.js';

--- a/packages/app/src/quality-scorer.ts
+++ b/packages/app/src/quality-scorer.ts
@@ -1,0 +1,71 @@
+/**
+ * Rule-based response quality scorer.
+ * Scores a response HTML string 0-10 based on structural quality rules.
+ */
+
+export interface QualityScore {
+    total: number;        // 0-10
+    breakdown: Record<string, boolean>;
+}
+
+export function scoreResponse(html: string): QualityScore {
+    const breakdown: Record<string, boolean> = {};
+    let total = 0;
+
+    // Has burnish-* components at all (+1)
+    const hasComponents = /burnish-/.test(html);
+    breakdown.hasComponents = hasComponents;
+    if (hasComponents) total += 1;
+
+    // Has stat-bar summary (+1)
+    const hasStatBar = /burnish-stat-bar/.test(html);
+    breakdown.hasStatBar = hasStatBar;
+    if (hasStatBar) total += 1;
+
+    // Has actions for next steps (+1)
+    const hasActions = /burnish-actions/.test(html);
+    breakdown.hasActions = hasActions;
+    if (hasActions) total += 1;
+
+    // Has sections for grouping (+1)
+    const hasSections = /burnish-section/.test(html);
+    breakdown.hasSections = hasSections;
+    if (hasSections) total += 1;
+
+    // No preamble text before first component (+1)
+    const startsWithComponent = /^\s*<burnish-/.test(html);
+    breakdown.noPreamble = startsWithComponent;
+    if (startsWithComponent) total += 1;
+
+    // No raw HTML tags (h1-h6, div, p, table) mixed in (+1)
+    const noRawHtml = !/<(h[1-6]|div|p|table)\b/.test(html);
+    breakdown.noRawHtml = noRawHtml;
+    if (noRawHtml) total += 1;
+
+    // No markdown code fences (+1)
+    const noCodeFences = !(/```/.test(html));
+    breakdown.noCodeFences = noCodeFences;
+    if (noCodeFences) total += 1;
+
+    // Uses multiple component types (+1)
+    const componentTypes = new Set((html.match(/burnish-\w+/g) || []).map(m => m));
+    const multipleTypes = componentTypes.size >= 2;
+    breakdown.multipleTypes = multipleTypes;
+    if (multipleTypes) total += 1;
+
+    // Has valid JSON in at least one attribute (+1)
+    let hasValidJson = false;
+    const jsonMatch = html.match(/(?:items|columns|rows|meta|fields|actions)='([^']*)'/);
+    if (jsonMatch) {
+        try { JSON.parse(jsonMatch[1]); hasValidJson = true; } catch { /* ignore */ }
+    }
+    breakdown.hasValidJson = hasValidJson;
+    if (hasValidJson) total += 1;
+
+    // Response is not empty and reasonable length (+1)
+    const reasonableLength = html.length > 50 && html.length < 100000;
+    breakdown.reasonableLength = reasonableLength;
+    if (reasonableLength) total += 1;
+
+    return { total, breakdown };
+}


### PR DESCRIPTION
## Summary

- Add `scoreResponse()` pure function in `packages/app/src/quality-scorer.ts` that evaluates response HTML against 10 structural quality rules, returning a 0-10 score with per-rule breakdown
- Integrate scoring into both `handleSubmit()` and `regenerateNode()` onDone callbacks, storing result as `node._qualityScore`
- Display quality score in the diagnostic panel alongside duration, tokens, and cost metrics

Closes #125

## Test plan

- [ ] `pnpm build` passes
- [ ] Submit a prompt and open diagnostic panel -- verify "Quality X/10" metric appears
- [ ] Regenerate a response and confirm quality score updates
- [ ] Verify text-only responses (no burnish components) score low, rich component responses score high