### PR TITLE
feat: feedback buttons and regeneration tracking

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -349,6 +349,8 @@ function createNodeEl(node) {
                 ${ICON_FOCUS}
             </button>
             <button class="burnish-node-refresh" title="Regenerate">${ICON_REFRESH}</button>
+            <button class="burnish-feedback-btn${node.feedback === 'up' ? ' active' : ''}" data-feedback="up" title="Good response">&#9650;</button>
+            <button class="burnish-feedback-btn${node.feedback === 'down' ? ' active' : ''}" data-feedback="down" title="Poor response">&#9660;</button>
             <button class="burnish-node-delete" data-delete-node="${node.id}" title="Delete this step">\u00d7</button>
         </div>
         <div class="burnish-node-content"></div>
@@ -356,7 +358,7 @@ function createNodeEl(node) {
 
     const header = div.querySelector('.burnish-node-header');
     header.addEventListener('click', (e) => {
-        if (e.target.closest('.burnish-node-delete') || e.target.closest('.burnish-node-maximize') || e.target.closest('.burnish-node-info') || e.target.closest('.burnish-node-refresh')) return;
+        if (e.target.closest('.burnish-node-delete') || e.target.closest('.burnish-node-maximize') || e.target.closest('.burnish-node-info') || e.target.closest('.burnish-node-refresh') || e.target.closest('.burnish-feedback-btn')) return;
         toggleNode(node.id);
     });
     header.addEventListener('keydown', (e) => {
@@ -383,6 +385,18 @@ function createNodeEl(node) {
         e.stopPropagation();
         toggleDiagnosticPanel(node.id);
     });
+    header.querySelectorAll('.burnish-feedback-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const value = btn.dataset.feedback;
+            node.feedback = node.feedback === value ? null : value;
+            header.querySelectorAll('.burnish-feedback-btn').forEach(b => b.classList.remove('active'));
+            if (node.feedback) {
+                header.querySelector(`.burnish-feedback-btn[data-feedback="${node.feedback}"]`)?.classList.add('active');
+            }
+            saveState();
+        });
+    });
     return div;
 }
 
@@ -391,6 +405,9 @@ async function regenerateNode(nodeId) {
     if (!session) return;
     const node = session.nodes.find(n => n.id === nodeId);
     if (!node || streamingNodeId) return;
+
+    // Track regeneration count as implicit negative signal
+    node._regenerateCount = (node._regenerateCount || 0) + 1;
 
     // Clear existing response and re-submit
     node.response = null;

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -856,11 +856,32 @@ body {
 }
 .burnish-node-header:hover .burnish-node-refresh { opacity: 1; }
 .burnish-node-refresh:hover { color: var(--burnish-accent, #4f6df5); }
+/* Feedback buttons */
+.burnish-feedback-btn {
+    opacity: 0.3;
+    font-size: 11px;
+    padding: 2px 4px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    border-radius: 3px;
+    transition: all 0.15s ease;
+    flex-shrink: 0;
+    line-height: 1;
+}
+.burnish-feedback-btn:hover { opacity: 0.7; }
+.burnish-feedback-btn.active { opacity: 1; background: rgba(79, 109, 245, 0.1); }
+.burnish-feedback-btn.active[data-feedback="up"] { color: var(--burnish-success, #22c55e); }
+.burnish-feedback-btn.active[data-feedback="down"] { color: var(--burnish-error, #ef4444); }
+.burnish-node-header:hover .burnish-feedback-btn { opacity: 0.5; }
+.burnish-node-header:hover .burnish-feedback-btn.active { opacity: 1; }
 /* Always show action buttons on expanded nodes */
 .burnish-node[data-collapsed="false"] .burnish-node-maximize,
 .burnish-node[data-collapsed="false"] .burnish-node-refresh,
 .burnish-node[data-collapsed="false"] .burnish-node-delete,
 .burnish-node[data-collapsed="false"] .burnish-node-info { opacity: 1; }
+.burnish-node[data-collapsed="false"] .burnish-feedback-btn { opacity: 0.5; }
+.burnish-node[data-collapsed="false"] .burnish-feedback-btn.active { opacity: 1; }
 .burnish-node-header:hover .burnish-node-delete { opacity: 1; }
 /* Inline status text in node header during streaming */
 .burnish-node-status {

--- a/packages/app/src/session-store.ts
+++ b/packages/app/src/session-store.ts
@@ -32,6 +32,8 @@ export interface AppNode {
     _toolHint?: { toolName: string; title: string } | null;
     _progressLog?: Array<{ stage: string; detail?: string; meta?: Record<string, string>; timestamp: number }>;
     _nodeIds?: string[];
+    feedback?: 'up' | 'down' | null;
+    _regenerateCount?: number;
     [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add `feedback` (`'up' | 'down' | null`) and `_regenerateCount` fields to `AppNode` interface in `@burnish/app`
- Render triangle up/down feedback buttons on node headers with toggle behavior, active styling, and persistence via `saveState()`
- Increment `_regenerateCount` at the start of `regenerateNode()` as an implicit negative quality signal

Closes #126, Closes #127

## Test plan
- [ ] Click thumbs-up button on a response node — should highlight green
- [ ] Click it again — should toggle off (deselect)
- [ ] Click thumbs-down — should highlight red
- [ ] Clicking up when down is active should switch to up
- [ ] Reload page — feedback state should persist
- [ ] Regenerate a node — verify `_regenerateCount` increments (inspect via devtools/IndexedDB)
- [ ] `pnpm build` passes cleanly