### PR TITLE
fix(demo): error recovery resets button state and shows styled error message

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -115,6 +115,16 @@ async function createSession() {
     persistence.markLoaded(session.id);
     renderSessionList();
     renderMainContent();
+
+    // Reset submit button state in case it was stuck from a previous session
+    const submitBtn = document.getElementById('btn-submit');
+    if (submitBtn) {
+        submitBtn.classList.remove('cancel');
+        submitBtn.innerHTML = ICON_SEND;
+    }
+    const promptInput = document.getElementById('prompt-input');
+    if (promptInput) promptInput.disabled = false;
+
     await saveState();
 }
 
@@ -552,7 +562,7 @@ async function regenerateNode(nodeId) {
             submitBtn.classList.remove('cancel');
             submitBtn.innerHTML = ICON_SEND;
             promptInput.disabled = false;
-            contentEl.innerHTML = `<div class="burnish-text-response">Error: ${escapeHtml(error)}</div>`;
+            contentEl.innerHTML = `<div class="burnish-text-response" style="color: var(--burnish-error, #ef4444);">Error: ${escapeHtml(error)}</div>`;
             node.response = error;
             node.type = 'text';
             node.summary = 'Error';
@@ -1591,7 +1601,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 submitBtn.classList.remove('cancel');
                 submitBtn.innerHTML = ICON_SEND;
                 promptInput.disabled = false;
-                contentEl.innerHTML = `<div class="burnish-text-response">Error: ${escapeHtml(error)}</div>`;
+                contentEl.innerHTML = `<div class="burnish-text-response" style="color: var(--burnish-error, #ef4444);">Error: ${escapeHtml(error)}</div>`;
                 node.response = error;
                 node.type = 'text';
                 node.summary = 'Error';


### PR DESCRIPTION
## Summary
Closes #144, Closes #145, Closes #146

## Root Cause
Three related issues in the demo app's error recovery path:

1. **#144 + #146**: The `onError` callbacks in both `handleSubmit()` and `regenerateNode()` rendered error messages as plain unstyled text, making errors hard to distinguish from normal responses. The button reset logic was already present but the error message lacked visual error styling.
2. **#145**: When creating a new session, the submit button state was not reset. If a previous session's LLM request failed or was cancelled, the button would remain in "cancel" (stop) state in the new session.

## Fix / Changes
All changes in `apps/demo/public/app.js`:

1. **Error message styling** — Added `style="color: var(--burnish-error, #ef4444);"` to the error `<div>` in both `onError` callbacks (`regenerateNode` and `handleSubmit`) so errors are visually distinct with red text.
2. **Button reset on new session** — Added button state reset logic at the end of `createSession()` that removes the `cancel` class, restores the send icon, and re-enables the prompt input.

## Verification
This is a state management and styling fix, not a layout change. No visual screenshot needed — verified by code path inspection.

## Test Plan
- [x] `pnpm build` passes
- [x] `npx playwright test` — 1 of 3 tests pass; 2 failures are pre-existing (require running LLM backend, not related to this change)