### PR TITLE
fix(components): use CSS grid for card layout in sections and node-content

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -456,11 +456,6 @@ body {
 }
 
 /* ── Component fade-in ── */
-/* Cards directly in node content should be full width, not fixed 340px */
-.burnish-node-content > burnish-card {
-    width: 100% !important;
-    flex: 1 1 auto !important;
-}
 .burnish-node-content > :not(.burnish-progress):not(.burnish-skeleton) {
     animation: fadeSlideIn 0.25s ease-out;
 }
@@ -921,13 +916,20 @@ body {
 }
 .burnish-node-content {
     padding: 16px;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: var(--burnish-space-lg, 16px);
     border: 1px solid var(--burnish-border, #e5e7eb);
     border-top: none;
     border-radius: 0 0 var(--burnish-radius-md, 4px) var(--burnish-radius-md, 4px);
     background: var(--burnish-surface-alt, #f5f6f8);
+}
+/* Non-card elements span full grid width */
+.burnish-node-content > :not(burnish-card) {
+    grid-column: 1 / -1;
+}
+@media (max-width: 768px) {
+    .burnish-node-content { grid-template-columns: 1fr; }
 }
 .burnish-node[data-collapsed="true"] .burnish-node-content {
     display: none;
@@ -1013,7 +1015,7 @@ body {
 [data-dashboard="true"] .burnish-content { margin-left: 0; }
 [data-dashboard="true"] .burnish-node-header { display: none; }
 [data-dashboard="true"] .burnish-node-prompt-bubble { display: none; }
-[data-dashboard="true"] .burnish-node[data-collapsed="true"] .burnish-node-content { display: flex; }
+[data-dashboard="true"] .burnish-node[data-collapsed="true"] .burnish-node-content { display: grid; }
 [data-dashboard="true"] .burnish-node-content {
     border: none;
     border-radius: 0;

--- a/packages/components/src/section.ts
+++ b/packages/components/src/section.ts
@@ -33,11 +33,12 @@ export class BurnishSection extends LitElement {
         .count { font-size: var(--burnish-font-size-md, 14px); font-weight: 600; color: var(--burnish-text-muted); }
         .content { overflow: hidden; transition: max-height var(--burnish-transition-normal); }
         .grid {
-            display: flex; flex-wrap: wrap;
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
             gap: var(--burnish-space-md, 12px);
         }
         :host([collapsed]) .content { max-height: 0 !important; }
-        @media (max-width: 768px) { .grid { flex-direction: column; } }
+        @media (max-width: 768px) { .grid { grid-template-columns: 1fr; } }
     `;
 
     declare label: string;


### PR DESCRIPTION
## Summary
Closes #153

## Root Cause
Cards rendered directly in `.burnish-node-content` (without a `burnish-section` wrapper) were forced to full width by a CSS override: `.burnish-node-content > burnish-card { width: 100% !important; flex: 1 1 auto !important; }`. This meant cards outside sections lost their grid layout and stacked vertically at full width.

Additionally, `burnish-section`'s `.grid` class used `display: flex; flex-wrap: wrap` which did not provide consistent responsive column sizing.

## Fix
1. **`packages/components/src/section.ts`** -- Changed `.grid` from `display: flex; flex-wrap: wrap` to `display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))` for proper responsive grid behavior. Updated the mobile media query to use `grid-template-columns: 1fr`.

2. **`apps/demo/public/style.css`** -- Three changes:
   - Removed the `.burnish-node-content > burnish-card { width: 100% !important }` override entirely
   - Changed `.burnish-node-content` from `display: flex; flex-direction: column` to `display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))` so bare cards also grid
   - Added `.burnish-node-content > :not(burnish-card) { grid-column: 1 / -1 }` so sections, tables, and other non-card elements still span the full width
   - Added mobile media query for single-column fallback at 768px
   - Updated dashboard mode collapsed override from `display: flex` to `display: grid`

## Verification
Screenshot taken after fix showing both scenarios:
- Cards directly in `.burnish-node-content` render in a responsive grid (3 columns at 1280px)
- Cards inside `burnish-section` also render in a responsive grid
- File: `tests/visual/screenshots/verify-153.png`

## Test Plan
- [x] `pnpm build` passes
- [x] `npx playwright test` -- 1 of 1 non-LLM test passes (2 LLM-dependent tests timeout as expected without a backend)
- [x] Visual verification screenshot confirms cards grid correctly in both contexts