### PR TITLE
fix(ui): filter boolean values from stat-bar and reset breadcrumb on new session

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -162,6 +162,7 @@ async function switchSession(sessionId) {
 
     renderMainContent();
     renderSessionList();
+    updateBreadcrumb();
     await saveState();
 }
 

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -174,7 +174,7 @@ export function renderParsedResult(parsed, label, sourceToolName) {
         }
 
         const meta = Object.entries(parsed)
-            .filter(([, v]) => typeof v !== 'object' || v === null)
+            .filter(([, v]) => (typeof v !== 'object' || v === null) && typeof v !== 'boolean')
             .slice(0, 10)
             .map(([k, v]) => ({ label: k.replace(/_/g, ' '), value: String(v ?? '') }));
         return `<burnish-card title="${escapeAttr(label)}" status="success" meta='${escapeAttr(JSON.stringify(meta))}'></burnish-card>`;


### PR DESCRIPTION
## Summary
Fixes #177

Two small UI bug fixes bundled together:
- Filter boolean values from card meta entries in `view-renderers.js` (matching the existing scalar fields filter)
- Add `updateBreadcrumb()` call to `switchSession()` in `app.js` so the breadcrumb resets when navigating to a new or different session

## Root Cause
1. The meta entries path in `renderParsedResult` was missing the `typeof v !== 'boolean'` filter that the scalar fields path already had, causing raw `true`/`false` values to appear in card meta display.
2. `switchSession()` called `renderMainContent()` and `renderSessionList()` but never called `updateBreadcrumb()`, so the breadcrumb from the previous session persisted after switching sessions.

## Fix / Changes
- `apps/demo/public/view-renderers.js`: Added `&& typeof v !== 'boolean'` to the meta entries filter on line 177, consistent with the scalar fields filter on line 163.
- `apps/demo/public/app.js`: Added `updateBreadcrumb()` call to `switchSession()` after `renderSessionList()`, matching the pattern already used in `createSession()`.

## Test Plan
- [x] `pnpm build` passes
- [ ] `npx playwright test` passes (pre-existing failures unrelated to this change)
- [ ] Visual verification: stat-bar no longer shows boolean values; breadcrumb resets on new session