### PR TITLE
feat(cli): export startServer as programmatic API

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,18 @@
   "bin": {
     "burnish": "./dist/cli.js"
   },
-  "main": "./dist/server.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    }
+  },
   "scripts": {
     "build": "tsc && node scripts/bundle-assets.js",
     "clean": "rm -rf dist assets"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Burnish CLI — programmatic API.
+ *
+ * @example
+ * ```ts
+ * import { McpHub } from '@burnish/server';
+ * import { startServerWithHub, buildApp } from 'burnish';
+ *
+ * const hub = new McpHub();
+ * await hub.initialize('./mcp-servers.json');
+ * await startServerWithHub(hub, { port: 4000 });
+ * ```
+ */
+
+export { startServerWithHub, buildApp } from './server.js';
+export type { ServerOptions } from './server.js';

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -18,6 +18,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const assetsDir = resolve(__dirname, '../assets');
 
 /**
+ * Options for starting the server with a pre-initialized McpHub.
+ */
+export interface ServerOptions {
+    /** Port to listen on (default: 3000). */
+    port?: number;
+    /** Open browser after starting (default: false). */
+    open?: boolean;
+}
+
+/**
  * Resolve a user-supplied path against a base directory and verify
  * it does not escape outside the base (prevents path traversal).
  */
@@ -45,15 +55,18 @@ function mimeType(filePath: string): string {
     return types[ext] || 'application/octet-stream';
 }
 
-export async function startServer(opts: CliOptions): Promise<void> {
-    const mcpHub = new McpHub();
+/**
+ * Build the Hono app wired to the given McpHub.
+ * Exported so consumers can mount the app in their own server.
+ */
+export function buildApp(hub: McpHub): Hono {
     const app = new Hono();
 
     // --- API Routes ---
 
     app.get('/api/servers', (c) => {
         try {
-            return c.json({ servers: mcpHub.getServerInfo() });
+            return c.json({ servers: hub.getServerInfo() });
         } catch (err) {
             console.error('[burnish] GET /api/servers error:', err);
             return c.json({ error: 'Internal server error' }, 500);
@@ -84,7 +97,7 @@ export async function startServer(opts: CliOptions): Promise<void> {
         }
 
         // Check tool exists — handle both short names and fully-qualified mcp__server__tool names
-        const allTools = mcpHub.getAllTools();
+        const allTools = hub.getAllTools();
         let toolName = body.toolName;
         let tool = allTools.find((t) => t.name === toolName);
         if (!tool) {
@@ -121,7 +134,7 @@ export async function startServer(opts: CliOptions): Promise<void> {
 
         try {
             const startTime = performance.now();
-            const result = await mcpHub.executeTool(toolName, args);
+            const result = await hub.executeTool(toolName, args);
             const durationMs = Math.round(performance.now() - startTime);
             return c.json({ result, toolName, serverName: tool.serverName, durationMs });
         } catch (err) {
@@ -161,13 +174,63 @@ export async function startServer(opts: CliOptions): Promise<void> {
         }
     });
 
-    // --- Startup ---
+    return app;
+}
+
+/**
+ * Start the Burnish server with a pre-initialized McpHub.
+ *
+ * This is the programmatic entry point for embedding Burnish in other
+ * applications (e.g., Express middleware, test harnesses).
+ *
+ * @param hub  An already-configured McpHub instance
+ * @param opts Server options (port, open browser)
+ */
+export async function startServerWithHub(hub: McpHub, opts?: ServerOptions): Promise<void> {
+    const port = opts?.port ?? 3000;
+    const shouldOpen = opts?.open ?? false;
+
+    const app = buildApp(hub);
+
+    serve({ fetch: app.fetch, port }, () => {
+        console.log(`[burnish] Explorer UI: http://localhost:${port}`);
+    });
+
+    if (shouldOpen) {
+        try {
+            await open(`http://localhost:${port}`);
+        } catch {
+            // Ignore — some environments don't have a browser
+        }
+    }
+
+    // Graceful shutdown
+    const shutdown = async () => {
+        console.log('\n[burnish] Shutting down...');
+        await hub.shutdown();
+        process.exit(0);
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+}
+
+/**
+ * Start the Burnish server from CLI options.
+ *
+ * Creates an McpHub, initializes it from the config, and delegates
+ * to startServerWithHub.
+ */
+export async function startServer(opts: CliOptions): Promise<void> {
+    const mcpHub = new McpHub();
 
     console.log('[burnish] Connecting to MCP server...');
 
     const configPath = await buildConfigFile(opts);
 
-    // Start the HTTP server immediately
+    // Start the HTTP server immediately (before MCP init completes)
+    const app = buildApp(mcpHub);
+
     serve({ fetch: app.fetch, port: opts.port }, () => {
         console.log(`[burnish] Explorer UI: http://localhost:${opts.port}`);
     });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "declaration": false,
+    "declaration": true,
     "declarationMap": false,
     "sourceMap": false
   },


### PR DESCRIPTION
## Summary
Closes #191

Extracts `buildApp()` and `startServerWithHub()` from the monolithic `startServer()` function so external consumers (Express middleware, test harnesses, embedded deployments) can programmatically start the Burnish UI with a pre-initialized `McpHub`.

## Fix / Changes
- **`buildApp(hub)`** — builds the Hono app wired to a given McpHub, returned for mounting in custom servers
- **`startServerWithHub(hub, opts?)`** — starts the HTTP server with a pre-initialized hub and optional port/open config
- **`startServer(opts)`** — unchanged CLI entry point, now delegates route setup to `buildApp()`
- **`ServerOptions`** interface exported for type-safe programmatic usage
- New `src/index.ts` barrel export with `startServerWithHub`, `buildApp`, and `ServerOptions`
- `package.json` gains `exports` map (`.` and `./server`) with `types` conditions
- `tsconfig.json` enables `declaration: true` so `.d.ts` files are emitted

## Verification
Non-visual change (API surface only). Existing CLI behavior is preserved — `startServer()` still works identically.

## Test Plan
- [x] `pnpm build` passes (zero errors)
- [x] `npx playwright test` passes (39 passed, headless)
- [x] No changes to existing API routes or static file serving