### PR TITLE
fix(ui): show risk level labels on tool cards and align stat-bar colors

### DIFF
--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -38,11 +38,16 @@ export function generateToolListingHtml(serverName, tools) {
         groups[verb].push(tool);
     }
 
-    const statItems = Object.entries(groups).map(([verb, items]) => ({
-        label: verb.charAt(0).toUpperCase() + verb.slice(1),
-        value: String(items.length),
-        color: items.some(t => WRITE_TOOL_RE.test(t.name)) ? 'warning' : 'info',
-    }));
+    const statItems = Object.entries(groups).map(([verb, items]) => {
+        const verbColor = HIGH_RISK_RE.test(verb + '_') ? 'error'
+            : MEDIUM_RISK_RE.test(verb + '_') ? 'warning'
+            : 'success';
+        return {
+            label: verb.charAt(0).toUpperCase() + verb.slice(1),
+            value: String(items.length),
+            color: verbColor,
+        };
+    });
     let html = `<burnish-stat-bar items='${escapeAttr(JSON.stringify(statItems))}'></burnish-stat-bar>`;
 
     html += `<div class="burnish-tool-filter-container">
@@ -54,8 +59,8 @@ export function generateToolListingHtml(serverName, tools) {
         html += `<burnish-section label="${escapeAttr(label)}" count="${items.length}" status="info">`;
         for (const tool of items) {
             const risk = assessToolRisk(tool);
-            const riskStatus = risk.level === 'high' ? 'error' : risk.level === 'medium' ? 'warning' : 'muted';
-            html += `<burnish-card title="${escapeAttr(tool.name)}" status="${riskStatus}" body="${escapeAttr(tool.description || '')}" item-id="${escapeAttr(tool.name)}"></burnish-card>`;
+            const riskStatus = risk.level === 'high' ? 'error' : risk.level === 'medium' ? 'warning' : 'success';
+            html += `<burnish-card title="${escapeAttr(tool.name)}" status="${riskStatus}" status-label="${risk.level}" body="${escapeAttr(tool.description || '')}" item-id="${escapeAttr(tool.name)}"></burnish-card>`;
         }
         html += `</burnish-section>`;
     }

--- a/apps/demo/public/shared.js
+++ b/apps/demo/public/shared.js
@@ -9,7 +9,7 @@ export const PURIFY_CONFIG = {
     ADD_ATTR: ['items', 'title', 'status', 'body', 'meta', 'columns', 'rows',
                'status-field', 'type', 'config', 'role', 'content', 'class',
                'label', 'count', 'collapsed', 'item-id', 'value', 'unit', 'trend',
-               'streaming', 'tool-id', 'fields', 'actions', 'color'],
+               'streaming', 'tool-id', 'fields', 'actions', 'color', 'status-label'],
     FORBID_TAGS: ['script', 'iframe', 'object', 'embed', 'form'],
     FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
 };

--- a/packages/app/src/output-transformer.ts
+++ b/packages/app/src/output-transformer.ts
@@ -104,6 +104,11 @@ export function transformOutput(html: string, options?: TransformOutputOptions):
             return;
         }
 
+        // Preserve risk-based status set by tool listing renderer
+        if (itemId && !itemId.includes('__')) {
+            return;
+        }
+
         // Cards in listing context: only override "success" → "info"
         if (status === 'success') {
             const parentSection = card.closest('burnish-section');
@@ -122,10 +127,16 @@ export function transformOutput(html: string, options?: TransformOutputOptions):
     });
 
     // Rule 1c: Stat-bar chips should use "info" when sibling content is informational
+    // Skip for tool listing stat-bars (where sibling cards have item-id without __)
     root.querySelectorAll('burnish-stat-bar').forEach(bar => {
         const parent = bar.parentElement;
         const hasSections = parent?.querySelector('burnish-section');
         if (hasSections) {
+            // Check if this is a tool listing context (cards with simple item-id)
+            const toolListingCard = parent?.querySelector('burnish-card[item-id]');
+            const isToolListing = toolListingCard && !toolListingCard.getAttribute('item-id')?.includes('__');
+            if (isToolListing) return; // Preserve risk-based stat-bar colors
+
             try {
                 const items = JSON.parse(bar.getAttribute('items') || '[]');
                 const hasGreen = items.some((i: any) => i.color === 'success' || i.color === 'healthy');

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -5,6 +5,7 @@ export class BurnishCard extends LitElement {
     static properties = {
         title: { type: String },
         status: { type: String },
+        'status-label': { type: String, attribute: 'status-label' },
         body: { type: String },
         meta: { type: String },
         'item-id': { type: String, attribute: 'item-id' },
@@ -159,6 +160,7 @@ export class BurnishCard extends LitElement {
 
     declare title: string;
     declare status: string;
+    declare 'status-label': string;
     declare body: string;
     declare meta: string;
     declare 'item-id': string;
@@ -261,7 +263,7 @@ export class BurnishCard extends LitElement {
         } catch { this._parseError = true; return; }
 
         const s = this.status || 'muted';
-        const badgeText = s.toUpperCase();
+        const badgeText = (this['status-label'] || s).toUpperCase();
         return html`
             <div class="card" data-status="${statusColor}" role="article" aria-label="${this.title || ''}"
                  @click=${this._handleClick} @keydown=${this._handleKeydown}>


### PR DESCRIPTION
## Summary
Fixes #195

Tool listing cards showed internal status names (SUCCESS, WARNING, ERROR) as badge text instead of the intended risk levels (LOW, MEDIUM, HIGH). Stat-bar category dots also used generic colors that didn't correspond to risk levels.

## Root Cause
1. The card component used `status` as badge text, but `status` controls styling (success/warning/error), not the display label
2. `transformOutput()` converted `success` status to `info` for all cards in sections, breaking low-risk tool coloring
3. Stat-bar chips used `WRITE_TOOL_RE` for a binary warning/info split instead of the three-tier risk classification

## Fix / Changes
- **card.ts**: Added `status-label` property that overrides badge text when set, decoupling display text from color styling
- **output-transformer.ts**: Skip `success→info` override for cards with `item-id` (tool listing cards) and for stat-bars in tool listing context
- **shared.js**: Added `status-label` to DOMPurify `ADD_ATTR` allowlist
- **deterministic-ui.js**: Pass `status-label="${risk.level}"` on tool cards, use `success` (not `muted`) for low risk, and map stat-bar dot colors using the HIGH/MEDIUM/LOW risk regexes

## Verification
![verify-195](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-195-20260406090230.png)

## Test Plan
- [x] `pnpm build` passes (verified by pre-commit hook)
- [x] Playwright screenshot confirms badges show LOW/MEDIUM/HIGH with correct colors
- [x] Stat-bar dots use risk-based colors (error/warning/success)