### PR TITLE
feat(ui): add risk summary stat-bar to tool listing

### DIFF
--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -50,6 +50,17 @@ export function generateToolListingHtml(serverName, tools) {
     });
     let html = `<burnish-stat-bar items='${escapeAttr(JSON.stringify(statItems))}'></burnish-stat-bar>`;
 
+    const riskCounts = { low: 0, medium: 0, high: 0 };
+    for (const tool of tools) {
+        riskCounts[assessToolRisk(tool).level]++;
+    }
+    const riskItems = [
+        { label: 'Low Risk', value: String(riskCounts.low), color: 'success' },
+        { label: 'Medium Risk', value: String(riskCounts.medium), color: 'warning' },
+        { label: 'High Risk', value: String(riskCounts.high), color: 'error' },
+    ].filter(i => Number(i.value) > 0);
+    html += `<burnish-stat-bar items='${escapeAttr(JSON.stringify(riskItems))}'></burnish-stat-bar>`;
+
     html += `<div class="burnish-tool-filter-container">
     <input type="text" class="burnish-tool-filter" placeholder="Filter tools..." autocomplete="off">
 </div>`;


### PR DESCRIPTION
## Summary
Closes #199 — adds a risk summary stat-bar to the tool listing.

## Changes
In generateToolListingHtml(), after the verb stat-bar, counts tools by risk level and renders a second burnish-stat-bar showing Low/Medium/High distribution.

## Verification
**Light mode:**
![verify-199-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-199-light-20260406102319.png)
**Dark mode:**
![verify-199-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-199-dark-20260406102327.png)

## Test Plan
- [x] pnpm build passes
- [x] Visual verification confirms both verb and risk stat-bars are visible
- [x] Light and dark themes render correctly