### PR TITLE
feat(cli): add withBurnishUI() middleware for MCP SDK servers

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,10 @@
     "./server": {
       "types": "./dist/server.d.ts",
       "import": "./dist/server.js"
+    },
+    "./middleware": {
+      "types": "./dist/middleware.d.ts",
+      "import": "./dist/middleware.js"
     }
   },
   "scripts": {
@@ -25,6 +29,7 @@
   "dependencies": {
     "@burnish/server": "workspace:*",
     "@hono/node-server": "^1.14.0",
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "hono": "^4.7.0",
     "open": "^10.0.0"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,3 +14,6 @@
 
 export { startServerWithHub, buildApp } from './server.js';
 export type { ServerOptions } from './server.js';
+
+export { withBurnishUI } from './middleware.js';
+export type { BurnishUIOptions } from './middleware.js';

--- a/packages/cli/src/middleware.ts
+++ b/packages/cli/src/middleware.ts
@@ -1,0 +1,88 @@
+/**
+ * withBurnishUI() — one-line middleware to serve the Burnish Explorer UI
+ * alongside an MCP SDK server running in the same process.
+ *
+ * @example
+ * ```ts
+ * import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+ * import { withBurnishUI } from "burnish/middleware";
+ *
+ * const server = new McpServer({ name: "my-server", version: "1.0.0" });
+ * server.tool("ping", {}, async () => ({ content: [{ type: "text", text: "pong" }] }));
+ *
+ * await withBurnishUI(server, { port: 3001 });
+ * ```
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+import { McpHub } from '@burnish/server';
+import { startServerWithHub, type ServerOptions } from './server.js';
+
+/**
+ * Options for `withBurnishUI()`.
+ */
+export interface BurnishUIOptions extends ServerOptions {
+    /**
+     * Display name for the server in the Explorer UI.
+     * Defaults to the server's declared name.
+     */
+    name?: string;
+}
+
+/**
+ * Resolve the low-level `Server` instance from either an `McpServer`
+ * (high-level wrapper) or a raw `Server`.
+ */
+function resolveServer(input: McpServer | Server): Server {
+    // McpServer has a `.server` property that holds the low-level Server
+    if ('server' in input && typeof (input as any).server?.connect === 'function') {
+        return (input as McpServer).server;
+    }
+    // Already a low-level Server
+    return input as Server;
+}
+
+/**
+ * Start the Burnish Explorer UI connected to an in-process MCP SDK server.
+ *
+ * Accepts either a high-level `McpServer` or a low-level `Server` instance
+ * from `@modelcontextprotocol/sdk`.
+ *
+ * @param mcpServer  An MCP SDK Server (or McpServer) instance with tools registered
+ * @param opts       Server options (port, open browser, display name)
+ */
+export async function withBurnishUI(
+    mcpServer: McpServer | Server,
+    opts?: BurnishUIOptions,
+): Promise<void> {
+    const server = resolveServer(mcpServer);
+
+    // Create an in-memory transport pair: one side for the server, one for the client
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    // Connect the MCP server to its side of the transport
+    await server.connect(serverTransport);
+
+    // Create a Burnish client and connect it to the other side
+    const client = new Client({ name: 'burnish-explorer', version: '0.1.0' });
+    await client.connect(clientTransport);
+
+    // Build an McpHub and register the connected client
+    const hub = new McpHub();
+    const serverName = opts?.name ?? (server as any).serverInfo?.name ?? 'mcp-server';
+    await hub.registerClient(serverName, client, clientTransport);
+
+    const serverInfo = hub.getServerInfo();
+    const totalTools = serverInfo.reduce((sum, s) => sum + s.toolCount, 0);
+    console.log(`[burnish] Connected in-process: ${totalTools} tools from "${serverName}"`);
+
+    // Start the HTTP server with the Burnish UI
+    await startServerWithHub(hub, {
+        port: opts?.port,
+        open: opts?.open,
+    });
+}

--- a/packages/server/src/mcp-hub.ts
+++ b/packages/server/src/mcp-hub.ts
@@ -6,6 +6,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { readFile, access } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { resolve } from 'node:path';
@@ -47,7 +48,7 @@ interface CliTool {
 interface ConnectedServer {
     name: string;
     client: Client;
-    transport: StdioClientTransport | StreamableHTTPClientTransport;
+    transport: Transport;
     tools: ToolDef[];
     config: McpServerConfig;
     status: 'connected' | 'disconnected';
@@ -90,6 +91,36 @@ export class McpHub {
         if (config.cliTools && Object.keys(config.cliTools).length > 0) {
             this.registerCliTools(config.cliTools);
         }
+    }
+
+    /**
+     * Register a pre-connected MCP client with the hub.
+     *
+     * This allows callers to connect a Client via any transport (e.g.
+     * InMemoryTransport) and hand it to the hub for tool discovery
+     * and execution.
+     */
+    async registerClient(
+        name: string,
+        client: Client,
+        transport: Transport,
+    ): Promise<void> {
+        const toolsResult = await client.listTools();
+        const tools: ToolDef[] = (toolsResult.tools || []).map((t: any) => ({
+            name: t.name,
+            description: t.description || '',
+            inputSchema: t.inputSchema || { type: 'object', properties: {} },
+            serverName: name,
+        }));
+
+        this.servers.push({
+            name,
+            client,
+            transport,
+            tools,
+            config: {},
+            status: 'connected',
+        });
     }
 
     private async connectServer(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.14.0
         version: 1.19.11(hono@4.12.9)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.1
+        version: 1.28.0(zod@4.3.6)
       hono:
         specifier: ^4.7.0
         version: 4.12.9


### PR DESCRIPTION
## Summary
Closes #200

Adds `withBurnishUI()`, a one-line API that lets MCP server developers serve the Burnish Explorer UI alongside their in-process MCP SDK server.

## Changes

### New: `packages/cli/src/middleware.ts`
- `withBurnishUI(server, opts?)` accepts an MCP SDK `McpServer` or low-level `Server` instance
- Creates an `InMemoryTransport` pair to connect the server to a Burnish `Client` in-process
- Registers the client with an `McpHub` and starts the Explorer HTTP server via `startServerWithHub()`
- Exported via `burnish/middleware` subpath and from the main `burnish` entry point

### Modified: `packages/server/src/mcp-hub.ts`
- Added `registerClient(name, client, transport)` public method to `McpHub` for registering pre-connected clients with any transport type
- Widened `ConnectedServer.transport` type from specific transports to the base `Transport` interface

### Modified: `packages/cli/package.json`
- Added `./middleware` subpath export
- Added `@modelcontextprotocol/sdk` as a direct dependency

### Modified: `packages/cli/src/index.ts`
- Re-exports `withBurnishUI` and `BurnishUIOptions`

## Usage
```typescript
import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
import { withBurnishUI } from "burnish/middleware";

const server = new McpServer({ name: "my-server", version: "1.0.0" });
server.tool("ping", {}, async () => ({
  content: [{ type: "text", text: "pong" }]
}));

await withBurnishUI(server, { port: 3001 });
```

## Test Plan
- [x] `pnpm build` passes
- [x] No visual changes (API-only feature)