### PR TITLE
feat(server): auto-retry with stricter prompt on prose-only output

### DIFF
--- a/packages/server/src/llm.ts
+++ b/packages/server/src/llm.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline';
 import type { McpHub, ToolDef } from './mcp-hub.js';
 import type { ConversationStore, Conversation } from './conversation.js';
-import { buildSystemPrompt, buildNoToolsPrompt, buildFormattingPrompt } from './prompt-template.js';
+import { buildSystemPrompt, buildNoToolsPrompt, buildFormattingPrompt, buildRetryPrompt } from './prompt-template.js';
 import { resolveIntent } from './intent-resolver.js';
 import { isWriteTool } from './guards.js';
 
@@ -120,9 +120,16 @@ export class LlmOrchestrator {
         console.log(`[llm] Backend: ${this.backend}, Model: ${this.model}${baseUrlSuffix}`);
     }
 
+    /** Regex to detect at least one burnish-* component tag in a response. */
+    private static readonly BURNISH_TAG_RE = /<burnish-[a-z]/;
+
     /**
      * Stream a response for a conversation.
      * Yields StreamChunk objects (content text or progress updates).
+     *
+     * When the model returns prose-only output (no burnish-* tags), a single
+     * retry is attempted with a stricter prompt that emphasizes component usage.
+     * This helps small models that sometimes emit markdown instead of components.
      */
     async *streamResponse(
         conversationId: string,
@@ -134,6 +141,48 @@ export class LlmOrchestrator {
             throw new Error(`Invalid model: ${requestModel}`);
         }
         const useModel = requestModel || this.model;
+
+        // First attempt
+        let fullContent = '';
+        for await (const chunk of this.streamBackend(conversationId, useModel, noTools)) {
+            if (chunk.type === 'content') {
+                fullContent += chunk.text;
+            }
+            yield chunk;
+        }
+
+        // Check if the response contains any burnish-* tags.
+        // Skip retry when: the response is empty, the model was asked a
+        // clarifying question (plain text is correct), or noTools was set
+        // (ambiguous/conversational requests don't need components).
+        if (
+            !fullContent ||
+            noTools ||
+            LlmOrchestrator.BURNISH_TAG_RE.test(fullContent)
+        ) {
+            return;
+        }
+
+        // Prose-only response detected — retry once with stricter prompt
+        console.log('[llm] Prose-only response detected, retrying with stricter prompt');
+        yield { type: 'progress', stage: 'retrying', detail: 'Reformatting with components…', meta: { model: useModel } };
+
+        // Inject a user message asking the model to reformat
+        this.conversations.addMessage(conversationId, 'user', buildRetryPrompt());
+
+        for await (const chunk of this.streamBackend(conversationId, useModel, noTools)) {
+            yield chunk;
+        }
+    }
+
+    /**
+     * Dispatch to the appropriate backend streaming implementation.
+     */
+    private async *streamBackend(
+        conversationId: string,
+        useModel: string,
+        noTools?: boolean,
+    ): AsyncGenerator<StreamChunk> {
         if (this.backend === 'cli') {
             yield* this.streamResponseCli(conversationId, useModel, noTools);
         } else if (this.backend === 'openai') {

--- a/packages/server/src/prompt-template.ts
+++ b/packages/server/src/prompt-template.ts
@@ -169,6 +169,29 @@ ${extraInstructions}`;
 }
 
 /**
+ * Stricter retry prompt appended as a user message when the model's first
+ * response contained no burnish-* component tags (i.e. pure prose/markdown).
+ *
+ * This gives the model one more chance to format the output correctly.
+ */
+export function buildRetryPrompt(): string {
+    return `Your previous response did not contain any burnish-* HTML components. This is incorrect.
+
+You MUST rewrite your response using ONLY burnish-* web components. Do NOT use markdown, plain text, or raw HTML.
+
+Required structure:
+1. Start with <burnish-stat-bar> to summarize key counts
+2. Use <burnish-section> to group related items
+3. Use <burnish-card> inside sections for individual items
+4. Use <burnish-table> for tabular data
+5. End with <burnish-actions> for next steps
+
+Your response must begin with a <burnish- tag. No preamble text. No markdown. Only burnish-* components.
+
+Rewrite your previous response now using this format.`;
+}
+
+/**
  * Minimal formatting prompt for the two-phase intent resolver.
  *
  * When the intent resolver has already executed a tool directly, we only


### PR DESCRIPTION
## Summary
Closes #124

## Fix / Changes
When the LLM returns a prose-only response (no `<burnish-*>` tags), the orchestrator now automatically retries once with a stricter prompt that emphasizes component usage. This addresses small models (e.g. via Ollama) that sometimes emit markdown or plain text instead of burnish components.

**Implementation details:**
- Added `buildRetryPrompt()` in `prompt-template.ts` — a firm user message instructing the model to rewrite its response using only burnish-* components with the required structure (stat-bar, sections, cards, etc.)
- Refactored `streamResponse()` in `llm.ts` to collect content from the first attempt, then check for burnish tags using a simple regex
- If no tags are found (and the request wasn't `noTools` or empty), a single retry is triggered by injecting the retry prompt as a user message and streaming again
- Extracted backend dispatch into a private `streamBackend()` helper to avoid duplication
- Single retry only — no infinite loops

**Skip conditions (no retry when):**
- Response is empty
- `noTools` was set (conversational/ambiguous requests where plain text is correct)
- Response already contains burnish-* tags

## Test Plan
- [x] `pnpm build` passes
- [ ] `npx playwright test` passes
- [ ] Manual test with a small model (e.g. Qwen via Ollama) that tends to produce markdown