### PR TITLE
feat(app): per-tool display preferences (#131)

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -31,7 +31,7 @@ import { PURIFY_CONFIG, WRITE_TOOL_RE, escapeHtml, escapeAttr } from './shared.j
 import {
     renderCardsView, renderTableView, renderJsonView,
     renderViewSwitcher, renderParsedResult, buildResultHtml,
-    renderSchemaTree,
+    renderSchemaTree, setToolViewPreference,
 } from './view-renderers.js';
 
 // ── Contextual actions ──
@@ -1049,6 +1049,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         btn.closest('.burnish-view-switcher').querySelectorAll('.burnish-view-btn').forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
+
+        // Save per-tool display preference
+        if (data.sourceToolName) {
+            setToolViewPreference(data.sourceToolName, viewType);
+        }
 
         const contentEl = document.querySelector(`.burnish-view-content[data-view-id="${dataId}"]`);
         if (!contentEl) {

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -9,6 +9,28 @@ import { generateContextualActions } from './contextual-actions.js';
 window._viewData = window._viewData || {};
 window._cardItems = window._cardItems || {};
 
+// ── Per-tool display preferences (localStorage) ──
+const TOOL_VIEW_PREFS_KEY = 'burnish:toolViewPrefs';
+
+export function getToolViewPreference(toolName) {
+    if (!toolName) return null;
+    try {
+        const prefs = JSON.parse(localStorage.getItem(TOOL_VIEW_PREFS_KEY) || '{}');
+        return prefs[toolName] || null;
+    } catch {
+        return null;
+    }
+}
+
+export function setToolViewPreference(toolName, viewType) {
+    if (!toolName || !viewType) return;
+    try {
+        const prefs = JSON.parse(localStorage.getItem(TOOL_VIEW_PREFS_KEY) || '{}');
+        prefs[toolName] = viewType;
+        localStorage.setItem(TOOL_VIEW_PREFS_KEY, JSON.stringify(prefs));
+    } catch { /* ignore storage errors */ }
+}
+
 export function renderViewSwitcher(dataId, activeView, count) {
     return `<div class="burnish-view-switcher" data-view-id="${dataId}">
         <button class="burnish-view-btn ${activeView === 'cards' ? 'active' : ''}" data-view="cards" data-target="${dataId}">Cards</button>
@@ -135,11 +157,15 @@ export function renderParsedResult(parsed, label, sourceToolName) {
             window._viewData[dataId] = { parsed, label, sourceToolName };
             boundCache(window._viewData);
 
-            const defaultView = 'cards';
+            const defaultView = getToolViewPreference(sourceToolName) || 'cards';
             let html = `<burnish-stat-bar items='${escapeAttr(JSON.stringify([{label:"Results",value:String(parsed.length),color:"info"}]))}'></burnish-stat-bar>`;
             html += renderViewSwitcher(dataId, defaultView, parsed.length);
             html += `<div class="burnish-view-content" data-view-id="${dataId}">`;
-            html += renderCardsView(parsed, sourceToolName, dataId);
+            let defaultContent;
+            if (defaultView === 'table') defaultContent = renderTableView(parsed, label);
+            else if (defaultView === 'json') defaultContent = renderJsonView(parsed);
+            else defaultContent = renderCardsView(parsed, sourceToolName, dataId);
+            html += defaultContent;
             html += '</div>';
 
             const actions = generateContextualActions(parsed, sourceToolName);


### PR DESCRIPTION
## Summary
Closes #131

Remembers the user's preferred view format (cards, table, or JSON) for each tool. When the user switches the view switcher tab for a tool result, that preference is saved to localStorage keyed by tool name. The next time that tool produces results, the saved view is shown by default instead of always defaulting to cards.

## Fix / Changes
- Added `getToolViewPreference()` and `setToolViewPreference()` helpers in `view-renderers.js` that persist preferences in localStorage under `burnish:toolViewPrefs`
- Updated `renderParsedResult()` to check for a saved preference before defaulting to cards, and render the correct initial view content (table/json/cards) accordingly
- Updated the view switcher click handler in `app.js` to call `setToolViewPreference()` when the user switches views, using the `sourceToolName` from the view data

## Verification
**Light mode (Cards view — default):**
![verify-131-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-131-light-20260406111909.png)

**Dark mode (Table view — after switching):**
![verify-131-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-131-dark-20260406111921.png)

Screenshots show the `directory_tree` tool results with the view switcher (Cards / Table / JSON tabs) visible. Light mode shows the default Cards view; dark mode shows the Table view after clicking the Table tab, demonstrating the view switching functionality. The "7 items" count is displayed next to the tabs.

## Test Plan
- [x] `pnpm build` passes
- [x] Visual verification — view switcher tabs (Cards/Table/JSON) render correctly in both light and dark themes
- [x] View switching works — clicking Table tab switches from Cards to Table view
- [x] Manual testing: connect an MCP server, execute a tool, switch views, reload, verify preference is retained