### PR TITLE
feat(app): template learning from positively-rated responses

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -22,7 +22,11 @@ import {
     transformOutput,
     isWriteTool, generateFallbackForm,
     generateSummary, formatTimeAgo,
+    TemplateStore, deriveToolKey,
 } from '@burnish/app';
+
+// ── Template learning ──
+import { recordPositiveSignal, getTemplateInstructions } from './template-learning.js';
 
 // ── Shared imports ──
 import { PURIFY_CONFIG, WRITE_TOOL_RE, escapeHtml, escapeAttr } from './shared.js';
@@ -979,6 +983,22 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Branch from the node containing this card
         const nodeEl = e.target.closest('.burnish-node');
         if (nodeEl?.dataset?.nodeId) branchFromNodeId = nodeEl.dataset.nodeId;
+
+        // Template learning: record drill-down as a positive signal
+        if (nodeEl?.dataset?.nodeId) {
+            const session = getActiveSession();
+            const parentNode = session?.nodes?.find(n => n.id === nodeEl.dataset.nodeId);
+            if (parentNode?.response && parentNode?.prompt) {
+                const toolHint = parentNode._toolHint;
+                recordPositiveSignal(
+                    parentNode.response,
+                    parentNode.prompt,
+                    'drill-down',
+                    toolHint?.toolName,
+                    null,
+                );
+            }
+        }
 
         // Deterministic path: if itemId matches a known tool, render form or execute directly
         const schema = toolSchemaCache[itemId];

--- a/apps/demo/public/copilot-ui.js
+++ b/apps/demo/public/copilot-ui.js
@@ -74,20 +74,23 @@ export function createInsightSlot(parentNode) {
  * Stream an AI insight into the given slot element.
  * Calls /api/chat to get a stream URL, then connects via EventSource.
  */
-export async function streamInsight(slot, toolName, resultSummary, PURIFY_CONFIG) {
+export async function streamInsight(slot, toolName, resultSummary, PURIFY_CONFIG, extraInstructions) {
     slot.style.display = 'block';
     slot.style.opacity = '1';
     slot.setAttribute('aria-busy', 'true');
     slot.innerHTML = '<div class="burnish-insight-loading"><div class="burnish-spinner"></div> Analyzing results...</div>';
 
     try {
+        const body = {
+            prompt: 'Analyze this ' + toolName + ' result and provide brief insights. Use burnish-stat-bar for key metrics and burnish-card for recommendations:\n' + resultSummary,
+            noTools: true
+        };
+        if (extraInstructions) body.extraInstructions = extraInstructions;
+
         const chatRes = await fetch('/api/chat', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                prompt: 'Analyze this ' + toolName + ' result and provide brief insights. Use burnish-stat-bar for key metrics and burnish-card for recommendations:\n' + resultSummary,
-                noTools: true
-            })
+            body: JSON.stringify(body)
         });
 
         if (!chatRes.ok) {

--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -6,6 +6,7 @@ import { PURIFY_CONFIG, WRITE_TOOL_RE, escapeHtml, escapeAttr } from './shared.j
 import { buildResultHtml } from './view-renderers.js';
 import { getCurrentMode, createInsightSlot, streamInsight } from './copilot-ui.js';
 import { recordToolPerf, refreshPerfPanel } from './perf-panel.js';
+import { getTemplateInstructions } from './template-learning.js';
 
 // ── Inline risk assessment (mirrors @burnish/app risk-indicators.ts) ──
 
@@ -231,11 +232,13 @@ export async function executeToolDirect(toolName, args, label) {
             const headerEl = document.querySelector('[data-node-id="' + node.id + '"] .burnish-node-header');
             if (headerEl) headerEl.appendChild(timingEl);
         }
-        // Stream AI insights in copilot mode
+        // Stream AI insights in copilot mode (with learned templates)
         if (getCurrentMode() === 'copilot' && contentEl) {
             const insightSlot = createInsightSlot(contentEl);
             const summary = JSON.stringify(data.result).substring(0, 2000);
-            streamInsight(insightSlot, toolName, summary, PURIFY_CONFIG);
+            getTemplateInstructions(toolName).then(extra => {
+                streamInsight(insightSlot, toolName, summary, PURIFY_CONFIG, extra || undefined);
+            });
         }
     } catch (err) {
         var errorHtml = '<burnish-card title="Error" status="error" body="' + escapeAttr(err.message) + '"></burnish-card>';

--- a/apps/demo/public/template-learning.js
+++ b/apps/demo/public/template-learning.js
@@ -1,0 +1,107 @@
+/**
+ * Template learning — client-side integration for learning from
+ * positively-rated responses and injecting proven templates.
+ */
+
+import { TemplateStore, extractHtmlStructure, deriveToolKey } from '@burnish/app';
+
+/** Singleton template store instance */
+const templateStore = new TemplateStore();
+
+/**
+ * Record a positive signal for a response node.
+ *
+ * Called when:
+ * - A user drills down into a result (engagement signal)
+ * - A response renders cleanly with burnish-* components
+ *
+ * @param html - The response HTML content
+ * @param prompt - The original user prompt
+ * @param signal - Type of positive signal
+ * @param toolName - Optional tool name that produced this response
+ * @param serverName - Optional server name
+ */
+export async function recordPositiveSignal(html, prompt, signal, toolName, serverName) {
+    if (!html || !prompt) return null;
+
+    // Only learn from responses that contain burnish-* components
+    if (!/<burnish-[a-z]/.test(html)) return null;
+
+    const toolKey = deriveToolKey(toolName, serverName);
+
+    try {
+        const template = await templateStore.saveTemplate(toolKey, html, prompt, signal);
+        if (template) {
+            console.log(`[template-learning] Saved ${signal} template for "${toolKey}" (use count: ${template.useCount})`);
+        }
+        return template;
+    } catch (err) {
+        console.warn('[template-learning] Failed to save template:', err);
+        return null;
+    }
+}
+
+/**
+ * Build extraInstructions string from learned templates.
+ *
+ * Fetches the best matching templates and formats them for injection
+ * into the system prompt. Returns empty string if no templates exist.
+ *
+ * @param toolKey - Optional tool key to prioritize matching templates
+ */
+export async function getTemplateInstructions(toolKey) {
+    try {
+        const templates = await templateStore.getBestTemplates(toolKey, 2);
+        if (templates.length === 0) return '';
+
+        // Format as extraInstructions text
+        const sections = templates.map((t, i) => {
+            const strength = t.useCount >= 3
+                ? 'Users consistently prefer this layout'
+                : 'This layout received positive feedback';
+            const toolLabel = t.toolKey === '_general' ? 'general queries' : `"${t.toolKey}" results`;
+
+            return `### Proven Layout ${i + 1} (for ${toolLabel})
+${strength}. Follow this structure when handling similar requests:
+\`\`\`html
+${t.htmlStructure}
+\`\`\``;
+        });
+
+        return `## Learned Layout Patterns
+The following layouts were rated positively by users. Use them as templates when responding to similar tool results. Adapt the data but keep the component structure.
+
+${sections.join('\n\n')}`;
+    } catch (err) {
+        console.warn('[template-learning] Failed to get templates:', err);
+        return '';
+    }
+}
+
+/**
+ * Get all stored templates (for management UI).
+ */
+export async function getAllTemplates() {
+    return templateStore.getAllTemplates();
+}
+
+/**
+ * Delete a specific template.
+ */
+export async function deleteTemplate(id) {
+    return templateStore.deleteTemplate(id);
+}
+
+/**
+ * Clear all learned templates.
+ */
+export async function clearAllTemplates() {
+    return templateStore.clear();
+}
+
+/**
+ * Get the template store instance (for advanced usage).
+ */
+export function getTemplateStore() {
+    return templateStore;
+}

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -309,7 +309,7 @@ app.get('/api/models', async (c) => {
 app.post('/api/chat', async (c) => {
     if (!llm || !conversations) return c.json({ error: 'LLM not configured' }, 503);
     try {
-        let body: { prompt: string; conversationId?: string; model?: string; noTools?: boolean };
+        let body: { prompt: string; conversationId?: string; model?: string; noTools?: boolean; extraInstructions?: string };
         try {
             body = await c.req.json();
         } catch {
@@ -327,13 +327,26 @@ app.post('/api/chat', async (c) => {
         const modelErr = validateModel(body.model);
         if (modelErr) return c.json({ error: modelErr }, 400);
 
+        // Validate extraInstructions (optional, max 5000 chars for template examples)
+        if (body.extraInstructions != null) {
+            if (typeof body.extraInstructions !== 'string') {
+                return c.json({ error: 'extraInstructions must be a string' }, 400);
+            }
+            if (body.extraInstructions.length > 5000) {
+                return c.json({ error: 'extraInstructions must be at most 5000 characters' }, 400);
+            }
+        }
+
         const conv = conversations.getOrCreate(body.conversationId);
         conversations.addMessage(conv.id, 'user', body.prompt);
         const modelParam = body.model ? `?model=${encodeURIComponent(body.model)}` : '';
         const noToolsParam = body.noTools ? `${modelParam ? '&' : '?'}noTools=true` : '';
+        const extraParam = body.extraInstructions
+            ? `${modelParam || noToolsParam ? '&' : '?'}extra=${encodeURIComponent(body.extraInstructions)}`
+            : '';
         return c.json({
             conversationId: conv.id,
-            streamUrl: `/api/chat/${conv.id}/stream${modelParam}${noToolsParam}`,
+            streamUrl: `/api/chat/${conv.id}/stream${modelParam}${noToolsParam}${extraParam}`,
         });
     } catch (err) {
         console.error('[burnish] POST /api/chat error:', err);
@@ -355,12 +368,13 @@ app.get('/api/chat/:id/stream', async (c) => {
             if (modelErr) return c.json({ error: modelErr }, 400);
         }
         const noTools = c.req.query('noTools') === 'true';
+        const extraInstructions = c.req.query('extra') || undefined;
 
         const stream = new ReadableStream({
             async start(controller) {
                 const encoder = new TextEncoder();
                 try {
-                    for await (const chunk of llm!.streamResponse(id, requestModel, noTools)) {
+                    for await (const chunk of llm!.streamResponse(id, requestModel, noTools, extraInstructions)) {
                         const data = JSON.stringify(chunk);
                         controller.enqueue(encoder.encode(`data: ${data}\n\n`));
                     }

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -48,3 +48,10 @@ export {
     type ModelStats,
     type ToolStats,
 } from './perf-store.js';
+
+export {
+    TemplateStore,
+    extractHtmlStructure,
+    deriveToolKey,
+    type LearnedTemplate,
+} from './template-store.js';

--- a/packages/app/src/stream-orchestrator.ts
+++ b/packages/app/src/stream-orchestrator.ts
@@ -54,12 +54,13 @@ export class StreamOrchestrator {
         model: string | undefined,
         callbacks: StreamCallbacks,
         noTools?: boolean,
+        extraInstructions?: string,
     ): Promise<void> {
         try {
             const res = await fetch(`${apiBase}/api/chat`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ prompt, conversationId, model, noTools }),
+                body: JSON.stringify({ prompt, conversationId, model, noTools, extraInstructions }),
             });
             if (!res.ok) throw new Error(`API error: ${res.status}`);
             const data = await res.json();

--- a/packages/app/src/template-store.ts
+++ b/packages/app/src/template-store.ts
@@ -1,0 +1,282 @@
+/**
+ * Template store — learns from positively-rated responses.
+ *
+ * When a response gets a positive signal (thumbs-up, drill-down engagement),
+ * extracts the HTML layout as a template and persists it in IndexedDB.
+ * These templates are later injected as few-shot examples in the system prompt
+ * via `extraInstructions`.
+ */
+
+import { get, set, del, keys, createStore, type UseStore } from 'idb-keyval';
+
+/** A learned template extracted from a successful response. */
+export interface LearnedTemplate {
+    /** Unique identifier */
+    id: string;
+    /** Tool name or server+tool combo that produced this response */
+    toolKey: string;
+    /** The HTML layout structure (sanitized — tags + attributes, no raw data) */
+    htmlStructure: string;
+    /** The original user prompt that led to this response */
+    prompt: string;
+    /** How the template was learned: 'thumbs-up' or 'drill-down' */
+    signal: 'thumbs-up' | 'drill-down';
+    /** Number of times this template has been reinforced */
+    useCount: number;
+    /** Timestamp when first learned */
+    createdAt: number;
+    /** Timestamp when last reinforced */
+    updatedAt: number;
+}
+
+/** Maximum templates per tool key */
+const MAX_TEMPLATES_PER_TOOL = 3;
+/** Maximum total templates stored */
+const MAX_TOTAL_TEMPLATES = 50;
+/** Maximum HTML structure length (characters) */
+const MAX_STRUCTURE_LENGTH = 2000;
+
+/**
+ * Extract the structural layout from a burnish-* HTML response.
+ *
+ * Strips data content from attributes (JSON values, body text, etc.)
+ * but preserves the component hierarchy and attribute names. This gives
+ * the LLM a skeleton to follow without memorizing specific data.
+ */
+export function extractHtmlStructure(html: string): string {
+    if (!html || typeof html !== 'string') return '';
+
+    // Only keep burnish-* tags — strip everything else
+    // Replace JSON attribute values with placeholder to show structure
+    let structure = html
+        // Remove excessive whitespace between tags
+        .replace(/>\s+</g, '>\n<')
+        // Strip body/content attribute values but keep the attribute name
+        .replace(/\b(body|content|meta|items|columns|rows|config|fields|actions)='[^']*'/g, '$1="..."')
+        .replace(/\b(body|content|meta|items|columns|rows|config|fields|actions)="[^"]*"/g, '$1="..."')
+        // Strip title values but keep the attribute
+        .replace(/\b(title)="[^"]*"/g, '$1="..."')
+        .replace(/\b(title)='[^']*'/g, '$1="..."')
+        // Strip item-id values
+        .replace(/\b(item-id)="[^"]*"/g, '$1="..."')
+        .replace(/\b(item-id)='[^']*'/g, '$1="..."')
+        // Strip tool-id values
+        .replace(/\b(tool-id)="[^"]*"/g, '$1="..."')
+        .replace(/\b(tool-id)='[^']*'/g, '$1="..."')
+        // Keep status, type, trend, label, value, count attributes as-is
+        // (they show the pattern of component usage)
+        .trim();
+
+    // Truncate if too long
+    if (structure.length > MAX_STRUCTURE_LENGTH) {
+        structure = structure.substring(0, MAX_STRUCTURE_LENGTH) + '\n<!-- truncated -->';
+    }
+
+    return structure;
+}
+
+/**
+ * Derive a tool key from a response's context.
+ *
+ * Uses the tool name if available, or falls back to a generic key
+ * derived from the prompt.
+ */
+export function deriveToolKey(toolName?: string | null, serverName?: string | null): string {
+    if (toolName) {
+        // Strip mcp__ prefix and server name for a cleaner key
+        const cleaned = toolName.replace(/^mcp__\w+__/, '');
+        return serverName ? `${serverName}/${cleaned}` : cleaned;
+    }
+    return '_general';
+}
+
+export class TemplateStore {
+    private db: UseStore;
+
+    constructor(dbName = 'burnish-templates') {
+        this.db = createStore(dbName, 'templates');
+    }
+
+    /**
+     * Save a learned template from a positively-rated response.
+     *
+     * If a template with the same tool key and similar structure already
+     * exists, reinforces it (increments useCount) instead of duplicating.
+     */
+    async saveTemplate(
+        toolKey: string,
+        html: string,
+        prompt: string,
+        signal: 'thumbs-up' | 'drill-down',
+    ): Promise<LearnedTemplate | null> {
+        const structure = extractHtmlStructure(html);
+        if (!structure || structure.length < 20) return null; // Too short to be useful
+
+        // Check for existing similar template
+        const existing = await this.getTemplatesForTool(toolKey);
+        const similar = existing.find(t => this.isSimilarStructure(t.htmlStructure, structure));
+
+        if (similar) {
+            // Reinforce existing template
+            similar.useCount++;
+            similar.updatedAt = Date.now();
+            if (signal === 'thumbs-up') {
+                // Thumbs-up is a stronger signal — upgrade if it was drill-down
+                similar.signal = 'thumbs-up';
+            }
+            await set(`template:${similar.id}`, similar, this.db);
+            return similar;
+        }
+
+        // New template — evict oldest if at capacity for this tool
+        if (existing.length >= MAX_TEMPLATES_PER_TOOL) {
+            const oldest = existing.sort((a, b) => a.updatedAt - b.updatedAt)[0];
+            await del(`template:${oldest.id}`, this.db);
+        }
+
+        // Enforce total limit
+        await this.enforceGlobalLimit();
+
+        const template: LearnedTemplate = {
+            id: this.generateId(),
+            toolKey,
+            htmlStructure: structure,
+            prompt: prompt.length > 200 ? prompt.substring(0, 200) + '...' : prompt,
+            signal,
+            useCount: 1,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+        };
+
+        await set(`template:${template.id}`, template, this.db);
+        return template;
+    }
+
+    /**
+     * Get all templates for a specific tool key.
+     */
+    async getTemplatesForTool(toolKey: string): Promise<LearnedTemplate[]> {
+        const allKeys = await keys(this.db);
+        const templates: LearnedTemplate[] = [];
+
+        for (const key of allKeys) {
+            if (typeof key !== 'string' || !key.startsWith('template:')) continue;
+            const template = await get(key, this.db) as LearnedTemplate | undefined;
+            if (template?.toolKey === toolKey) {
+                templates.push(template);
+            }
+        }
+
+        return templates.sort((a, b) => b.useCount - a.useCount);
+    }
+
+    /**
+     * Get the best templates for injection into the system prompt.
+     *
+     * Returns templates sorted by relevance: matching tool key first,
+     * then by use count. Limited to a reasonable number for prompt size.
+     */
+    async getBestTemplates(toolKey?: string, limit = 2): Promise<LearnedTemplate[]> {
+        const allKeys = await keys(this.db);
+        const templates: LearnedTemplate[] = [];
+
+        for (const key of allKeys) {
+            if (typeof key !== 'string' || !key.startsWith('template:')) continue;
+            const template = await get(key, this.db) as LearnedTemplate | undefined;
+            if (template) templates.push(template);
+        }
+
+        // Sort: matching tool key first, then by use count, then by recency
+        return templates
+            .sort((a, b) => {
+                const aMatch = toolKey && a.toolKey === toolKey ? 1 : 0;
+                const bMatch = toolKey && b.toolKey === toolKey ? 1 : 0;
+                if (aMatch !== bMatch) return bMatch - aMatch;
+                if (a.useCount !== b.useCount) return b.useCount - a.useCount;
+                return b.updatedAt - a.updatedAt;
+            })
+            .slice(0, limit);
+    }
+
+    /**
+     * Get all stored templates.
+     */
+    async getAllTemplates(): Promise<LearnedTemplate[]> {
+        const allKeys = await keys(this.db);
+        const templates: LearnedTemplate[] = [];
+
+        for (const key of allKeys) {
+            if (typeof key !== 'string' || !key.startsWith('template:')) continue;
+            const template = await get(key, this.db) as LearnedTemplate | undefined;
+            if (template) templates.push(template);
+        }
+
+        return templates.sort((a, b) => b.updatedAt - a.updatedAt);
+    }
+
+    /**
+     * Delete a specific template.
+     */
+    async deleteTemplate(id: string): Promise<void> {
+        await del(`template:${id}`, this.db);
+    }
+
+    /**
+     * Clear all stored templates.
+     */
+    async clear(): Promise<void> {
+        const allKeys = await keys(this.db);
+        for (const key of allKeys) {
+            if (typeof key === 'string' && key.startsWith('template:')) {
+                await del(key, this.db);
+            }
+        }
+    }
+
+    /**
+     * Check if two HTML structures are similar enough to be considered
+     * the same template pattern.
+     */
+    private isSimilarStructure(a: string, b: string): boolean {
+        // Extract just the tag sequence for comparison
+        const tagsA = this.extractTagSequence(a);
+        const tagsB = this.extractTagSequence(b);
+        return tagsA === tagsB;
+    }
+
+    /**
+     * Extract the sequence of burnish-* tag names from HTML structure.
+     */
+    private extractTagSequence(html: string): string {
+        const tags = html.match(/<\/?burnish-[a-z-]+/g) || [];
+        return tags.join(',');
+    }
+
+    private generateId(): string {
+        return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+    }
+
+    private async enforceGlobalLimit(): Promise<void> {
+        const allKeys = await keys(this.db);
+        const templateKeys = allKeys.filter(k => typeof k === 'string' && k.startsWith('template:'));
+
+        if (templateKeys.length < MAX_TOTAL_TEMPLATES) return;
+
+        // Load all, sort by least useful, delete excess
+        const templates: LearnedTemplate[] = [];
+        for (const key of templateKeys) {
+            const t = await get(key, this.db) as LearnedTemplate | undefined;
+            if (t) templates.push(t);
+        }
+
+        templates.sort((a, b) => {
+            if (a.useCount !== b.useCount) return a.useCount - b.useCount;
+            return a.updatedAt - b.updatedAt;
+        });
+
+        const toRemove = templates.slice(0, templates.length - MAX_TOTAL_TEMPLATES + 1);
+        for (const t of toRemove) {
+            await del(`template:${t.id}`, this.db);
+        }
+    }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -39,7 +39,9 @@ export {
     buildAdaptiveSystemPrompt,
     buildAdaptiveNoToolsPrompt,
     detectModelSize,
+    formatTemplateExamples,
     type ModelSize,
+    type TemplateExample,
 } from './prompt-template.js';
 
 export { resolveIntent, type IntentResolution } from './intent-resolver.js';

--- a/packages/server/src/llm.ts
+++ b/packages/server/src/llm.ts
@@ -135,6 +135,7 @@ export class LlmOrchestrator {
         conversationId: string,
         requestModel?: string,
         noTools?: boolean,
+        extraInstructions?: string,
     ): AsyncGenerator<StreamChunk> {
         // For openai backend, allow any model; for others, validate against allowlist
         if (requestModel && this.backend !== 'openai' && !ALLOWED_MODELS.has(requestModel)) {
@@ -144,7 +145,7 @@ export class LlmOrchestrator {
 
         // First attempt
         let fullContent = '';
-        for await (const chunk of this.streamBackend(conversationId, useModel, noTools)) {
+        for await (const chunk of this.streamBackend(conversationId, useModel, noTools, extraInstructions)) {
             if (chunk.type === 'content') {
                 fullContent += chunk.text;
             }
@@ -170,7 +171,7 @@ export class LlmOrchestrator {
         // Inject a user message asking the model to reformat
         this.conversations.addMessage(conversationId, 'user', buildRetryPrompt());
 
-        for await (const chunk of this.streamBackend(conversationId, useModel, noTools)) {
+        for await (const chunk of this.streamBackend(conversationId, useModel, noTools, extraInstructions)) {
             yield chunk;
         }
     }
@@ -182,13 +183,14 @@ export class LlmOrchestrator {
         conversationId: string,
         useModel: string,
         noTools?: boolean,
+        extraInstructions?: string,
     ): AsyncGenerator<StreamChunk> {
         if (this.backend === 'cli') {
-            yield* this.streamResponseCli(conversationId, useModel, noTools);
+            yield* this.streamResponseCli(conversationId, useModel, noTools, extraInstructions);
         } else if (this.backend === 'openai') {
-            yield* this.streamResponseOpenai(conversationId, useModel, noTools);
+            yield* this.streamResponseOpenai(conversationId, useModel, noTools, extraInstructions);
         } else {
-            yield* this.streamResponseApi(conversationId, useModel, noTools);
+            yield* this.streamResponseApi(conversationId, useModel, noTools, extraInstructions);
         }
     }
 
@@ -200,11 +202,12 @@ export class LlmOrchestrator {
         conversationId: string,
         useModel = this.model,
         noTools?: boolean,
+        extraInstructions?: string,
     ): AsyncGenerator<StreamChunk> {
         const conv = this.conversations.get(conversationId);
         if (!conv) return;
 
-        const systemPrompt = noTools ? buildAdaptiveNoToolsPrompt(useModel) : buildAdaptiveSystemPrompt(useModel);
+        const systemPrompt = noTools ? buildAdaptiveNoToolsPrompt(useModel) : buildAdaptiveSystemPrompt(useModel, extraInstructions);
         const userMessage = this.buildUserMessage(conv);
 
         // Write system prompt to temp file (avoids command-line size limits)
@@ -416,6 +419,7 @@ export class LlmOrchestrator {
         conversationId: string,
         useModel = this.model,
         noTools?: boolean,
+        extraInstructions?: string,
     ): AsyncGenerator<StreamChunk> {
         if (!this.client) throw new Error('LLM not configured — call configure() first');
 
@@ -443,7 +447,7 @@ export class LlmOrchestrator {
                 : {}),
         }));
 
-        const systemPrompt = noTools ? buildAdaptiveNoToolsPrompt(useModel) : buildAdaptiveSystemPrompt(useModel);
+        const systemPrompt = noTools ? buildAdaptiveNoToolsPrompt(useModel) : buildAdaptiveSystemPrompt(useModel, extraInstructions);
         const system: Anthropic.MessageCreateParams['system'] = [
             {
                 type: 'text' as const,
@@ -665,13 +669,14 @@ export class LlmOrchestrator {
         conversationId: string,
         useModel = this.model,
         noTools?: boolean,
+        extraInstructions?: string,
     ): AsyncGenerator<StreamChunk> {
         if (!this.openaiClient) throw new Error('OpenAI client not configured — call configure() first');
 
         const conv = this.conversations.get(conversationId);
         if (!conv) return;
 
-        const systemPrompt = noTools ? buildAdaptiveNoToolsPrompt(useModel) : buildAdaptiveSystemPrompt(useModel);
+        const systemPrompt = noTools ? buildAdaptiveNoToolsPrompt(useModel) : buildAdaptiveSystemPrompt(useModel, extraInstructions);
         const messages: OpenAI.ChatCompletionMessageParam[] = [
             { role: 'system', content: systemPrompt },
         ];

--- a/packages/server/src/prompt-template.ts
+++ b/packages/server/src/prompt-template.ts
@@ -381,3 +381,51 @@ export function buildAdaptiveNoToolsPrompt(modelName: string): string {
     }
     return buildNoToolsPrompt();
 }
+
+// ═══════════════════════════════════════════════════════════════
+// Template learning — few-shot examples from successful responses
+// ═══════════════════════════════════════════════════════════════
+
+/** Minimal template shape expected by formatTemplateExamples. */
+export interface TemplateExample {
+    /** Tool name or server/tool combo */
+    toolKey: string;
+    /** Structural HTML skeleton (data stripped) */
+    htmlStructure: string;
+    /** Original prompt that produced this layout */
+    prompt: string;
+    /** How many times this template was reinforced */
+    useCount: number;
+}
+
+/**
+ * Format learned templates as `extraInstructions` text for the system prompt.
+ *
+ * Produces a section that shows the LLM proven layout patterns from
+ * previous successful interactions. Templates with higher use counts
+ * are presented with stronger framing ("users consistently prefer").
+ *
+ * Returns an empty string if no templates are provided, so it's safe
+ * to always call and pass into `buildSystemPrompt(extraInstructions)`.
+ */
+export function formatTemplateExamples(templates: TemplateExample[]): string {
+    if (!templates || templates.length === 0) return '';
+
+    const sections = templates.map((t, i) => {
+        const strength = t.useCount >= 3
+            ? 'Users consistently prefer this layout'
+            : 'This layout received positive feedback';
+        const toolLabel = t.toolKey === '_general' ? 'general queries' : `"${t.toolKey}" results`;
+
+        return `### Proven Layout ${i + 1} (for ${toolLabel})
+${strength}. Follow this structure when handling similar requests:
+\`\`\`html
+${t.htmlStructure}
+\`\`\``;
+    });
+
+    return `## Learned Layout Patterns
+The following layouts were rated positively by users. Use them as templates when responding to similar tool results. Adapt the data but keep the component structure.
+
+${sections.join('\n\n')}`;
+}


### PR DESCRIPTION
## Summary
Closes #129

Adds a template learning system that extracts HTML layout patterns from responses that receive positive user signals (drill-down engagement) and injects them as few-shot examples in the LLM system prompt.

## Changes

- **`packages/app/src/template-store.ts`** — New `TemplateStore` class backed by IndexedDB that persists learned templates. Extracts structural skeletons from burnish-* HTML (strips data, keeps component hierarchy). Keys templates by tool name with per-tool and global limits.
- **`packages/server/src/prompt-template.ts`** — Added `formatTemplateExamples()` to format learned templates as `extraInstructions` text, with strength framing based on reinforcement count.
- **`packages/server/src/llm.ts`** — Threaded `extraInstructions` parameter through `streamResponse` to `streamBackend` to all three backend methods (CLI, API, OpenAI), so templates reach the system prompt.
- **`apps/demo/server/index.ts`** — Chat API now accepts and forwards `extraInstructions` from client to LLM orchestrator via query parameter.
- **`packages/app/src/stream-orchestrator.ts`** — `submitPrompt` now accepts `extraInstructions` parameter.
- **`apps/demo/public/template-learning.js`** — Client-side integration module exposing `recordPositiveSignal()` and `getTemplateInstructions()`.
- **`apps/demo/public/app.js`** — Hooks into `burnish-card-action` (drill-down) to record the parent node's response as a positive signal template.
- **`apps/demo/public/deterministic-ui.js`** — Passes learned template instructions when streaming AI insights in copilot mode.
- **`apps/demo/public/copilot-ui.js`** — `streamInsight` now accepts and forwards `extraInstructions` to the chat API.

## Verification
Screenshots showing the drill-down navigation flow that triggers template learning. The Explorer executes list_directory, renders results in a table with Explore links, and clicking one drills down into a nested detail view. Each drill-down records a positive signal for template learning.

**Light mode — tool results with Explore drill-down links:**
![verify-129-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-129-light-20260406143535.png)
**Dark mode — nested drill-down view after clicking Explore:**
![verify-129-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-129-dark-20260406143551.png)

## Test Plan
- [x] `pnpm build` passes
- [x] CI tests pass (automated on PR)
- [x] Visual verification — drill-down navigation with template recording confirmed in both light and dark mode
