### PR TITLE
feat(ui): cross-server data mesh with source-origin badges (#111)

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1100,7 +1100,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         let html;
-        if (viewType === 'cards') html = renderCardsView(data.parsed, data.sourceToolName, dataId);
+        if (viewType === 'cards') html = renderCardsView(data.parsed, data.sourceToolName, dataId, data.sourceName);
         else if (viewType === 'json') html = renderJsonView(data.parsed);
         else html = renderTableView(data.parsed, data.label);
 

--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -60,7 +60,7 @@ export function generateToolListingHtml(serverName, tools) {
         for (const tool of items) {
             const risk = assessToolRisk(tool);
             const riskStatus = risk.level === 'high' ? 'error' : risk.level === 'medium' ? 'warning' : 'success';
-            html += `<burnish-card title="${escapeAttr(tool.name)}" status="${riskStatus}" status-label="${risk.level}" body="${escapeAttr(tool.description || '')}" item-id="${escapeAttr(tool.name)}"></burnish-card>`;
+            html += `<burnish-card title="${escapeAttr(tool.name)}" status="${riskStatus}" status-label="${risk.level}" body="${escapeAttr(tool.description || '')}" item-id="${escapeAttr(tool.name)}" source="${escapeAttr(serverName)}"></burnish-card>`;
         }
         html += `</burnish-section>`;
     }
@@ -194,7 +194,7 @@ export async function executeToolDirect(toolName, args, label) {
         });
         var data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Execution failed');
-        var resultHtml = buildResultHtml(data.result, label, toolName);
+        var resultHtml = buildResultHtml(data.result, label, toolName, data.serverName);
         var contentEl = node ? document.querySelector('[data-node-id="' + node.id + '"] .burnish-node-content') : null;
         if (contentEl) {
             contentEl.innerHTML = DOMPurify.sanitize(resultHtml, PURIFY_CONFIG);

--- a/apps/demo/public/shared.js
+++ b/apps/demo/public/shared.js
@@ -11,7 +11,7 @@ export const PURIFY_CONFIG = {
                'status-field', 'type', 'config', 'role', 'content', 'class',
                'label', 'count', 'collapsed', 'item-id', 'value', 'unit', 'trend',
                'streaming', 'tool-id', 'fields', 'actions', 'color', 'status-label', 'variant',
-               'steps'],
+               'steps', 'source'],
     FORBID_TAGS: ['script', 'iframe', 'object', 'embed', 'form'],
     FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
 };

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -63,12 +63,13 @@ export function inferCardStatus(item, sourceToolName) {
     return 'success';
 }
 
-export function renderCardsView(items, sourceToolName, dataId) {
+export function renderCardsView(items, sourceToolName, dataId, sourceName) {
     const viewId = dataId || ('cv-' + Date.now() + '-' + Math.random().toString(36).substring(2, 6));
     window._cardItems = window._cardItems || {};
     window._cardItems[viewId] = items;
     boundCache(window._cardItems);
 
+    const sourceAttr = sourceName ? ` source="${escapeAttr(sourceName)}"` : '';
     let html = '<div class="burnish-cards-grid">';
     for (let i = 0; i < Math.min(items.length, 50); i++) {
         const item = items[i];
@@ -87,7 +88,7 @@ export function renderCardsView(items, sourceToolName, dataId) {
         html += `<burnish-card title="${escapeAttr(title)}" status="${status}"
             body="${escapeAttr(body)}"
             meta='${escapeAttr(JSON.stringify(meta))}'
-            item-id="${escapeAttr((dataId || viewId) + ':' + i)}"></burnish-card>`;
+            item-id="${escapeAttr((dataId || viewId) + ':' + i)}"${sourceAttr}></burnish-card>`;
     }
     if (items.length > 50) {
         html += '<div class="burnish-truncation-notice">Showing 50 of ' + items.length + ' results</div>';
@@ -147,14 +148,15 @@ export function renderJsonView(items) {
     </div>`;
 }
 
-export function renderParsedResult(parsed, label, sourceToolName) {
+export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
+    const sourceAttr = sourceName ? ` source="${escapeAttr(sourceName)}"` : '';
     if (Array.isArray(parsed)) {
         if (parsed.length === 0) {
-            return `<burnish-card title="${escapeAttr(label)}" status="muted" body="No results"></burnish-card>`;
+            return `<burnish-card title="${escapeAttr(label)}" status="muted" body="No results"${sourceAttr}></burnish-card>`;
         }
         if (typeof parsed[0] === 'object') {
             const dataId = 'vd-' + Date.now() + '-' + Math.random().toString(36).substring(2, 6);
-            window._viewData[dataId] = { parsed, label, sourceToolName };
+            window._viewData[dataId] = { parsed, label, sourceToolName, sourceName };
             boundCache(window._viewData);
 
             const defaultView = getToolViewPreference(sourceToolName) || 'cards';
@@ -164,7 +166,7 @@ export function renderParsedResult(parsed, label, sourceToolName) {
             let defaultContent;
             if (defaultView === 'table') defaultContent = renderTableView(parsed, label);
             else if (defaultView === 'json') defaultContent = renderJsonView(parsed);
-            else defaultContent = renderCardsView(parsed, sourceToolName, dataId);
+            else defaultContent = renderCardsView(parsed, sourceToolName, dataId, sourceName);
             html += defaultContent;
             html += '</div>';
 
@@ -175,7 +177,7 @@ export function renderParsedResult(parsed, label, sourceToolName) {
             return html;
         }
         return parsed.slice(0, 20).map(item =>
-            `<burnish-card title="${escapeAttr(String(item))}" status="info"></burnish-card>`
+            `<burnish-card title="${escapeAttr(String(item))}" status="info"${sourceAttr}></burnish-card>`
         ).join('');
     }
 
@@ -195,7 +197,7 @@ export function renderParsedResult(parsed, label, sourceToolName) {
                 }));
                 html += `<burnish-stat-bar items='${escapeAttr(JSON.stringify(statItems))}'></burnish-stat-bar>`;
             }
-            html += renderParsedResult(parsed[nestedKey], nestedKey, sourceToolName);
+            html += renderParsedResult(parsed[nestedKey], nestedKey, sourceToolName, sourceName);
             return html;
         }
 
@@ -203,10 +205,10 @@ export function renderParsedResult(parsed, label, sourceToolName) {
             .filter(([, v]) => (typeof v !== 'object' || v === null) && typeof v !== 'boolean')
             .slice(0, 10)
             .map(([k, v]) => ({ label: k.replace(/_/g, ' '), value: String(v ?? '') }));
-        return `<burnish-card title="${escapeAttr(label)}" status="success" meta='${escapeAttr(JSON.stringify(meta))}'></burnish-card>`;
+        return `<burnish-card title="${escapeAttr(label)}" status="success" meta='${escapeAttr(JSON.stringify(meta))}'${sourceAttr}></burnish-card>`;
     }
 
-    return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(String(parsed))}"></burnish-card>`;
+    return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(String(parsed))}"${sourceAttr}></burnish-card>`;
 }
 
 // ── Schema Tree Renderer ──
@@ -352,16 +354,17 @@ function tryParseDirectoryListing(result, label) {
     return html;
 }
 
-export function buildResultHtml(result, label, sourceToolName) {
+export function buildResultHtml(result, label, sourceToolName, sourceName) {
     try {
         const parsed = JSON.parse(result);
-        const inner = renderParsedResult(parsed, label, sourceToolName);
+        const inner = renderParsedResult(parsed, label, sourceToolName, sourceName);
         return `<div class="burnish-result-wrapper" data-raw-result="${escapeAttr(result.substring(0, 50000))}">${inner}</div>`;
     } catch {
         // Try to parse as a directory listing before falling back to plain text
         const dirHtml = tryParseDirectoryListing(result, label);
         if (dirHtml) return dirHtml;
 
-        return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(result.substring(0, 1000))}"></burnish-card>`;
+        const sourceAttr = sourceName ? ` source="${escapeAttr(sourceName)}"` : '';
+        return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(result.substring(0, 1000))}"${sourceAttr}></burnish-card>`;
     }
 }

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -9,6 +9,7 @@ export class BurnishCard extends LitElement {
         body: { type: String },
         meta: { type: String },
         'item-id': { type: String, attribute: 'item-id' },
+        source: { type: String },
         _parseError: { state: true },
         _expanded: { state: true },
     };
@@ -43,6 +44,25 @@ export class BurnishCard extends LitElement {
         }
         .card:hover .expand-btn { display: flex; }
         .expand-btn:hover { color: var(--burnish-accent, #8B3A3A); }
+        .source-badge {
+            position: absolute;
+            bottom: var(--burnish-space-sm, 8px);
+            right: var(--burnish-space-sm, 8px);
+            font-size: 10px;
+            font-weight: 500;
+            color: var(--burnish-text-muted, #9C8F8F);
+            background: var(--burnish-surface-alt, #F8F5F5);
+            border: 1px solid var(--burnish-border-light, #F0EAEA);
+            border-radius: 3px;
+            padding: 1px 6px;
+            line-height: 1.4;
+            letter-spacing: 0.3px;
+            opacity: 0.7;
+            transition: opacity var(--burnish-transition-fast);
+            pointer-events: none;
+            z-index: 1;
+        }
+        .card:hover .source-badge { opacity: 1; }
         .card {
             background: var(--burnish-surface, #fff);
             border-radius: var(--burnish-radius-md, 4px);
@@ -164,6 +184,7 @@ export class BurnishCard extends LitElement {
     declare body: string;
     declare meta: string;
     declare 'item-id': string;
+    declare source: string;
     declare _parseError: boolean;
     declare _expanded: boolean;
 
@@ -302,6 +323,7 @@ export class BurnishCard extends LitElement {
                     `;
                 })()}
                 ${this['item-id'] ? html`<div class="card-action" role="button" tabindex="0">Explore \u2192</div>` : ''}
+                ${this.source ? html`<span class="source-badge" title="Source: ${this.source}">${this.source}</span>` : ''}
             </div>
         `;
     }

--- a/packages/renderer/src/sanitizer.ts
+++ b/packages/renderer/src/sanitizer.ts
@@ -17,7 +17,7 @@ export interface SanitizerConfig {
 
 /** Default Burnish component definitions */
 export const BURNISH_COMPONENTS: ComponentDef[] = [
-    { tag: 'burnish-card', attrs: ['title', 'status', 'body', 'meta', 'item-id'] },
+    { tag: 'burnish-card', attrs: ['title', 'status', 'body', 'meta', 'item-id', 'source'] },
     { tag: 'burnish-stat-bar', attrs: ['items'] },
     { tag: 'burnish-table', attrs: ['title', 'columns', 'rows', 'status-field'] },
     { tag: 'burnish-chart', attrs: ['type', 'config'] },


### PR DESCRIPTION
## Summary
Closes #111

## Changes
- Added `source` property to `burnish-card` — subtle origin badge in bottom-right
- Tool listing and result cards show server name via `source` attribute  
- Source threading through all view renderers and view switcher
- Registered in sanitizer and DOMPurify config

## Verification
**Light mode:**
![verify-111-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-111-light-20260406162903.png)
**Dark mode:**
![verify-111-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-111-dark-20260406162911.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification — source-origin badges showing "filesystem" visible on all tool cards in both light and dark themes