### PR TITLE
ci: add CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '25 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
Closes #226

Adds a GitHub CodeQL code scanning workflow to detect security vulnerabilities and code quality issues in the TypeScript/JavaScript codebase.

## Fix / Changes
- New `.github/workflows/codeql.yml` workflow that:
  - Runs on push to `main`, PRs against `main`, and weekly (Monday 06:25 UTC)
  - Analyzes `javascript-typescript` using CodeQL v3 actions
  - Uses autobuild for zero-config TypeScript analysis
  - Sets minimal required permissions (`security-events: write`, `contents: read`, `actions: read`)

## Test Plan
- [ ] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] CodeQL workflow triggers on this PR and completes successfully