### PR TITLE
chore: add Code of Conduct, Contributing guide, and Security policy (#225)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at danfking on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to Burnish
+
+Thanks for your interest in contributing to Burnish! This guide will help you get started.
+
+## Getting Started
+
+```bash
+git clone https://github.com/danfking/burnish.git
+cd burnish
+pnpm install
+pnpm build
+pnpm dev:nomodel  # Start Explorer mode (no LLM needed)
+```
+
+Open http://localhost:3000 to see the app.
+
+## Reporting Issues
+
+- **Bugs**: Use the [Bug Report](https://github.com/danfking/burnish/issues/new?template=bug.md) template
+- **Features**: Use the [Feature Request](https://github.com/danfking/burnish/issues/new?template=feature.md) template
+
+## Development Workflow
+
+1. **Create an issue** first — every change starts as a GitHub issue
+2. **Branch from main**: `feat/<issue>-<slug>`, `fix/<issue>-<slug>`, or `chore/<issue>-<slug>`
+3. **Build and test**: `pnpm build` must pass with zero errors
+4. **Create a PR** linked to the issue with `Closes #N`
+5. **Review**: The maintainer reviews all PRs before merging
+
+## Branch Naming
+
+```
+feat/42-add-tooltip        # New features
+fix/15-chart-rendering     # Bug fixes
+chore/30-update-deps       # Maintenance
+```
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description
+
+feat(components): add tooltip component
+fix(renderer): resolve streaming parser race condition
+chore: update dependencies
+```
+
+**Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `style`, `perf`, `ci`, `build`
+
+## Code Style
+
+- **TypeScript** for all packages and server code
+- **Lit 3** for web components (extends `LitElement`)
+- **CSS custom properties** with `--burnish-*` prefix
+- **Tag prefix** `burnish-` for all custom elements
+- **No framework dependencies** — works in React, Vue, Angular, vanilla
+
+## Project Structure
+
+```
+packages/
+  components/   # @burnish/components — Lit web components
+  renderer/     # @burnish/renderer — streaming HTML parser
+  server/       # @burnish/server — MCP hub + LLM orchestrator
+  app/          # @burnish/app — headless SDK
+  cli/          # burnish — CLI tool
+apps/
+  demo/         # Demo app shell
+```
+
+## Pull Request Checklist
+
+- [ ] `pnpm build` passes
+- [ ] PR title follows conventional commit format
+- [ ] PR body includes `Closes #N` linking the issue
+- [ ] Visual changes include screenshots (light + dark mode)
+- [ ] No unrelated changes included
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [AGPL-3.0 License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest on `main` | Yes |
+| Previous releases | Best effort |
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use [GitHub's private vulnerability reporting](https://github.com/danfking/burnish/security/advisories/new) to report security issues.
+
+Alternatively, contact the maintainer directly via GitHub: [@danfking](https://github.com/danfking)
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected component(s) and version(s)
+- Potential impact
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Assessment**: Within 1 week
+- **Fix**: Depends on severity, but we aim for critical fixes within 2 weeks
+
+## Scope
+
+This security policy covers:
+
+- `@burnish/components` — web component library
+- `@burnish/renderer` — streaming HTML parser and sanitizer
+- `@burnish/server` — MCP hub and LLM orchestrator
+- `@burnish/app` — headless SDK
+- `burnish` CLI
+
+**Out of scope**: Third-party MCP servers connected via Burnish. Security issues with MCP servers should be reported to their respective maintainers.
+
+## Security Practices
+
+- All user-provided HTML is sanitized via DOMPurify before rendering
+- Component attributes are validated and constrained
+- The pre-commit hook scans for accidentally committed secrets
+- Dependencies are monitored via Dependabot alerts


### PR DESCRIPTION
## Summary
Closes #225

## Changes
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **CONTRIBUTING.md** — Development setup, branch naming, commit format, PR process, code style
- **SECURITY.md** — Vulnerability reporting via GitHub private advisories, response timeline, scope

## Test Plan
- [ ] GitHub community standards checklist shows 100%
- [ ] pnpm build passes (no code changes)