### PR TITLE
fix(security): resolve polynomial regex (ReDoS) vulnerabilities

### DIFF
--- a/packages/renderer/src/component-validator.ts
+++ b/packages/renderer/src/component-validator.ts
@@ -272,25 +272,25 @@ function validateElement(
  */
 function parseAttrsFromHtml(html: string): Record<string, string> {
     const attrs: Record<string, string> = {};
-    // Match attribute="value", attribute='value', or bare attribute
-    const re = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')|(\b[\w-]+)\b(?!=)/g;
-    let m: RegExpExecArray | null;
 
     // Skip past the opening tag name
     const tagEnd = html.indexOf(' ');
     if (tagEnd === -1) return attrs;
     const attrString = html.substring(tagEnd);
 
-    while ((m = re.exec(attrString)) !== null) {
-        if (m[1]) {
-            // key="value" or key='value'
-            attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? '';
-        } else if (m[4]) {
-            // bare boolean attribute
-            const name = m[4].toLowerCase();
-            if (name !== '/' && name !== '>') {
-                attrs[name] = '';
-            }
+    // Match key="value" or key='value' pairs
+    const kvRe = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+    let m: RegExpExecArray | null;
+    while ((m = kvRe.exec(attrString)) !== null) {
+        attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? '';
+    }
+
+    // Match bare boolean attributes (words not followed by =)
+    const bareRe = /\b([\w-]+)\b(?!\s*=)/g;
+    while ((m = bareRe.exec(attrString)) !== null) {
+        const name = m[1].toLowerCase();
+        if (name !== '/' && name !== '>' && !(name in attrs)) {
+            attrs[name] = '';
         }
     }
 

--- a/packages/renderer/src/markdown-fallback.ts
+++ b/packages/renderer/src/markdown-fallback.ts
@@ -66,7 +66,7 @@ export function convertMarkdownToComponents(
 // ---------------------------------------------------------------------------
 
 const TABLE_ROW_RE = /^\|(.+)\|$/;
-const TABLE_SEPARATOR_RE = /^\|[\s:]*-{2,}[\s:]*(?:\|[\s:]*-{2,}[\s:]*)*\|$/;
+const TABLE_SEPARATOR_RE = /^\| *:?-{2,}:? *(\| *:?-{2,}:? *)*\|$/;
 
 function hasMarkdownTable(text: string): boolean {
     const lines = text.split('\n');
@@ -156,7 +156,7 @@ function convertTables(text: string, prefix: string, minRows: number): string {
         let title = '';
         if (table.startIndex > 0) {
             const prev = lines[table.startIndex - 1].trim();
-            const headerMatch = prev.match(/^#{1,6}\s+(.+)$/);
+            const headerMatch = prev.match(/^#{1,6}\s+(\S.*)$/);
             if (headerMatch) {
                 title = headerMatch[1];
                 // Remove the header line too
@@ -188,7 +188,7 @@ function convertTables(text: string, prefix: string, minRows: number): string {
 // ---------------------------------------------------------------------------
 
 // Matches "**Label:** value" or "- **Label:** value"
-const KV_RE = /^[-*]?\s*\*\*(.+?)\*\*[:\s]+(.+)$/;
+const KV_RE = /^[-*]?\s*\*\*([^*]+)\*\*[:\s]+(\S.*)$/;
 
 function hasKeyValuePattern(text: string): boolean {
     const lines = text.split('\n').map(l => l.trim());
@@ -247,8 +247,8 @@ function convertKeyValueBlocks(text: string, prefix: string): string {
 // Header + list conversion
 // ---------------------------------------------------------------------------
 
-const HEADER_RE = /^(#{1,6})\s+(.+)$/;
-const BULLET_RE = /^[-*+]\s+(.+)$/;
+const HEADER_RE = /^(#{1,6})\s+(\S.*)$/;
+const BULLET_RE = /^[-*+]\s+(\S.*)$/;
 
 function hasHeaderWithList(text: string): boolean {
     const lines = text.split('\n').map(l => l.trim());
@@ -365,11 +365,11 @@ function toKey(header: string): string {
 /** Strip inline markdown bold/italic/code formatting */
 function stripInlineMarkdown(text: string): string {
     return text
-        .replace(/\*\*(.+?)\*\*/g, '$1')
-        .replace(/\*(.+?)\*/g, '$1')
-        .replace(/_(.+?)_/g, '$1')
-        .replace(/`(.+?)`/g, '$1')
-        .replace(/\[(.+?)\]\(.+?\)/g, '$1')
+        .replace(/\*\*([^*]+)\*\*/g, '$1')
+        .replace(/\*([^*]+)\*/g, '$1')
+        .replace(/_([^_]+)_/g, '$1')
+        .replace(/`([^`]+)`/g, '$1')
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
         .trim();
 }
 

--- a/packages/renderer/src/stream-parser.ts
+++ b/packages/renderer/src/stream-parser.ts
@@ -30,6 +30,25 @@ export interface StreamParserOptions {
 const DEFAULT_PREFIX = 'burnish-';
 const DEFAULT_CONTAINERS = new Set(['burnish-section']);
 
+const MCP_OPEN_TAG = '<use_mcp_tool';
+const MCP_CLOSE_TAG = '</use_mcp_tool>';
+
+/**
+ * Strip MCP tool call XML blocks using indexOf instead of regex
+ * to avoid polynomial backtracking on malformed input.
+ */
+function stripMcpToolCalls(text: string): string {
+    let result = text;
+    let start = result.indexOf(MCP_OPEN_TAG);
+    while (start !== -1) {
+        const end = result.indexOf(MCP_CLOSE_TAG, start);
+        if (end === -1) break; // Incomplete block — leave as is
+        result = result.substring(0, start) + result.substring(end + MCP_CLOSE_TAG.length);
+        start = result.indexOf(MCP_OPEN_TAG);
+    }
+    return result;
+}
+
 /**
  * Check if text contains any component tags with the given prefix.
  */
@@ -50,7 +69,7 @@ export function findStreamElements(
     const elements: StreamElement[] = [];
 
     // Clean MCP tool call XML blocks
-    const cleaned = text.replace(/<use_mcp_tool[\s\S]*?<\/use_mcp_tool>/g, '');
+    const cleaned = stripMcpToolCalls(text);
 
     // Match component tags + common HTML tags
     const extraTags = options.extraTags ?? ['div', 'h[1-6]', 'p', 'section', 'ul', 'ol', 'table'];
@@ -164,7 +183,7 @@ export function extractHtmlContent(
     _renderMarkdown?: (text: string) => string,
     fallbackOptions?: FallbackOptions,
 ): string {
-    let cleaned = text.replace(/<use_mcp_tool[\s\S]*?<\/use_mcp_tool>/g, '');
+    let cleaned = stripMcpToolCalls(text);
     const tagRe = new RegExp(`<${prefix}[a-z]`);
     const htmlStart = cleaned.search(tagRe);
 

--- a/packages/server/src/intent-resolver.ts
+++ b/packages/server/src/intent-resolver.ts
@@ -113,7 +113,7 @@ function parseExplicitToolCall(
     tools: ToolDef[],
 ): IntentResolution | null {
     const match = prompt.match(
-        /^Call the tool\s+(\S+)\s+with\s+.*parameters?:?\s*(.*)/i,
+        /^Call the tool\s+(\S+)\s+with\s+[^:]*parameters?:?\s*(.*)/i,
     );
     if (!match) return null;
 


### PR DESCRIPTION
## Summary
Fixes #229

Resolves 13 polynomial regex (ReDoS) vulnerabilities flagged by CodeQL across four files in the renderer and server packages.

## Root Cause
Several regex patterns used overlapping quantifiers that could cause exponential backtracking on adversarial input. For example, `\s+(.+)$` allows the engine to partition whitespace between `\s+` and `.+` in multiple ways, and `[\s\S]*?` with a literal suffix creates polynomial scan behavior on unmatched input.

## Fix / Changes

**`packages/renderer/src/markdown-fallback.ts`** (9 fixes):
- `HEADER_RE` / `BULLET_RE`: Changed `\s+(.+)$` to `\s+(\S.*)$` so the first captured char cannot overlap with the preceding `\s+`
- Inline header match (line 159): Same fix as `HEADER_RE`
- `KV_RE`: Replaced `.+?` inside `\*\*...\*\*` with `[^*]+` (negated class avoids backtracking through asterisks) and `[:\s]+(.+)$` with `[:\s]+(\S.*)$`
- `TABLE_SEPARATOR_RE`: Tightened `[\s:]*-{2,}[\s:]*` to ` *:?-{2,}:? *` using literal spaces and optional single colon, eliminating quantifier overlap between group iterations
- `stripInlineMarkdown`: Replaced all `.+?` lazy quantifiers with negated character classes (`[^*]+`, `[^_]+`, `` [^`]+ ``, `[^\]]+`, `[^)]+`)

**`packages/server/src/intent-resolver.ts`** (1 fix):
- `parseExplicitToolCall`: Replaced `\s+.*parameters?` with `\s+[^:]*parameters?` so the `.*` cannot overlap with the trailing `\s*(.*)` — the `[^:]` class cannot match the colon that terminates the parameters prefix

**`packages/renderer/src/stream-parser.ts`** (2 fixes):
- Replaced both `<use_mcp_tool[\s\S]*?<\/use_mcp_tool>` regex substitutions with an `indexOf`-based `stripMcpToolCalls()` helper that loops through open/close tag pairs without any regex

**`packages/renderer/src/component-validator.ts`** (1 fix):
- Split the combined attribute regex into two separate passes: one for `key="value"` pairs and one for bare boolean attributes, eliminating the alternation that caused backtracking between the two branches

## Test Plan
- [x] `pnpm build` passes with zero errors
- [ ] CI tests pass (automated on PR)

[skip-screenshot] — Security fix, no visual changes.