### PR TITLE
fix(ci): allow [skip-screenshot] marker for non-visual changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --json body -q .body)
+          # Allow skipping screenshot for non-visual changes (security fixes, refactors)
+          if echo "$PR_BODY" | grep -qi '\[skip.screenshot\]'; then
+            echo "Screenshot check skipped via [skip-screenshot] marker."
+            exit 0
+          fi
           if echo "$PR_BODY" | grep -q '!\[verify-'; then
             echo "Screenshot found in PR body."
           else
             echo "::error::This PR changes visual files but has no verification screenshot."
-            echo "Add a screenshot with the pattern ![verify-<issue>](...) to the PR body."
+            echo "Add a screenshot with ![verify-<issue>](...) or add [skip-screenshot] if this is a non-visual change."
             exit 1
           fi


### PR DESCRIPTION
## Summary
The screenshot-check CI job fails on PRs that touch packages/renderer or packages/components even when the changes are non-visual (security fixes, refactors).

## Fix
Allow `[skip-screenshot]` marker in the PR body to bypass the screenshot check for changes that modify visual-path files but don't affect visual output.

## Test Plan
- [x] pnpm build passes
- [ ] Security PRs with [skip-screenshot] in body pass the check