### PR TITLE
fix(ci): publish CLI first, scoped packages gracefully skip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,11 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm -r publish --no-git-checks --access public
+      - name: Publish CLI package (unscoped)
+        run: pnpm --filter burnish publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish scoped packages (@burnish/*)
+        run: pnpm --filter '@burnish/*' publish --no-git-checks --access public || echo "Scoped packages skipped — @burnish org may not exist yet"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Scoped @burnish/* packages fail because the npm org doesn't exist yet. Split publish into two steps: CLI (unscoped) publishes first, scoped packages skip gracefully.

[skip-screenshot]