### PR TITLE
chore(packages): rename scope from @burnish/* to @burnishdev/*

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm --filter burnish publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish scoped packages (@burnish/*)
-        run: pnpm --filter '@burnish/*' publish --no-git-checks --access public || echo "Scoped packages skipped — @burnish org may not exist yet"
+      - name: Publish scoped packages (@burnishdev/*)
+        run: pnpm --filter '@burnishdev/*' publish --no-git-checks --access public || echo "Scoped packages skipped — @burnish org may not exist yet"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,23 +94,23 @@ All commit messages must follow `type(scope): description`:
 ```
 burnish/
 ├── packages/
-│   ├── components/     # @burnish/components — Lit web components (card, table, chart, etc.)
-│   ├── renderer/       # @burnish/renderer — streaming HTML parser, sanitizer, component mapper
-│   ├── server/         # @burnish/server — MCP hub, LLM orchestrator, conversation store
-│   └── app/            # @burnish/app — headless SDK: nav tree, sessions, streaming, output transform
+│   ├── components/     # @burnishdev/components — Lit web components (card, table, chart, etc.)
+│   ├── renderer/       # @burnishdev/renderer — streaming HTML parser, sanitizer, component mapper
+│   ├── server/         # @burnishdev/server — MCP hub, LLM orchestrator, conversation store
+│   └── app/            # @burnishdev/app — headless SDK: nav tree, sessions, streaming, output transform
 ├── apps/
 │   └── demo/           # Thin demo shell — Hono routes + DOM rendering/events
-│       ├── server/     # index.ts (~200 LOC Hono wrapper over @burnish/server)
-│       └── public/     # SPA shell, app.js (DOM-only, imports @burnish/app + @burnish/renderer)
+│       ├── server/     # index.ts (~200 LOC Hono wrapper over @burnishdev/server)
+│       └── public/     # SPA shell, app.js (DOM-only, imports @burnishdev/app + @burnishdev/renderer)
 ├── package.json        # pnpm workspace root
 └── CLAUDE.md           # this file
 ```
 
 ### Package Responsibilities
-- **@burnish/components** — Lit web components, publishable to npm/CDN
-- **@burnish/renderer** — Stream parser, HTML sanitizer config, component mapper
-- **@burnish/server** — `McpHub` (MCP client management), `LlmOrchestrator` (dual CLI/API backends), `ConversationStore`, guards, catalog, prompt template
-- **@burnish/app** — Framework-agnostic headless SDK: `SessionStore` (IndexedDB), `StreamOrchestrator` (SSE), navigation tree utils, output transformer, drill-down helpers, summary utils
+- **@burnishdev/components** — Lit web components, publishable to npm/CDN
+- **@burnishdev/renderer** — Stream parser, HTML sanitizer config, component mapper
+- **@burnishdev/server** — `McpHub` (MCP client management), `LlmOrchestrator` (dual CLI/API backends), `ConversationStore`, guards, catalog, prompt template
+- **@burnishdev/app** — Framework-agnostic headless SDK: `SessionStore` (IndexedDB), `StreamOrchestrator` (SSE), navigation tree utils, output transformer, drill-down helpers, summary utils
 
 ## Conventions
 
@@ -211,13 +211,13 @@ Status values: `success`, `warning`, `error`, `muted` (maps to semantic colors)
 
 ```html
 <!-- CDN (simplest) -->
-<script type="module" src="https://cdn.jsdelivr.net/npm/@burnish/components/dist/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@burnishdev/components/dist/index.js"></script>
 ```
 
 ```javascript
-// npm install @burnish/components
+// npm install @burnishdev/components
 // Re-register with custom prefix if needed:
-import { BurnishCard } from '@burnish/components';
+import { BurnishCard } from '@burnishdev/components';
 customElements.define('xm-card', class extends BurnishCard {});
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,10 @@ chore: update dependencies
 
 ```
 packages/
-  components/   # @burnish/components — Lit web components
-  renderer/     # @burnish/renderer — streaming HTML parser
-  server/       # @burnish/server — MCP hub + LLM orchestrator
-  app/          # @burnish/app — headless SDK
+  components/   # @burnishdev/components — Lit web components
+  renderer/     # @burnishdev/renderer — streaming HTML parser
+  server/       # @burnishdev/server — MCP hub + LLM orchestrator
+  app/          # @burnishdev/app — headless SDK
   cli/          # burnish — CLI tool
 apps/
   demo/         # Demo app shell

--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ Connect web search + filesystem. Search, summarize, save.
 
 ```html
 <script type="module"
-  src="https://cdn.jsdelivr.net/npm/@burnish/components/dist/index.js"></script>
+  src="https://cdn.jsdelivr.net/npm/@burnishdev/components/dist/index.js"></script>
 <link rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@burnish/components/dist/tokens.css" />
+  href="https://cdn.jsdelivr.net/npm/@burnishdev/components/dist/tokens.css" />
 
 <burnish-card
   title="API Gateway"
@@ -275,15 +275,15 @@ Connect web search + filesystem. Search, summarize, save.
 > Available after npm publish.
 
 ```bash
-npm install @burnish/components
+npm install @burnishdev/components
 ```
 
 ```javascript
-import '@burnish/components';
+import '@burnishdev/components';
 
 // Components auto-register with burnish-* prefix.
 // Custom prefix:
-import { BurnishCard } from '@burnish/components';
+import { BurnishCard } from '@burnishdev/components';
 customElements.define('my-card', class extends BurnishCard {});
 ```
 
@@ -292,11 +292,11 @@ customElements.define('my-card', class extends BurnishCard {});
 > Available after npm publish.
 
 ```bash
-npm install @burnish/renderer
+npm install @burnishdev/renderer
 ```
 
 ```javascript
-import { findStreamElements, appendStreamElement } from '@burnish/renderer';
+import { findStreamElements, appendStreamElement } from '@burnishdev/renderer';
 
 const elements = findStreamElements(chunk);
 for (const el of elements) {
@@ -354,10 +354,10 @@ pnpm clean            # Clean all build artifacts
 ```
 burnish/
 ├── packages/
-│   ├── components/       @burnish/components — 10 Lit web components
-│   ├── renderer/         @burnish/renderer  — streaming parser + sanitizer
-│   ├── app/              @burnish/app — drill-down logic + stream orchestration
-│   └── server/           @burnish/server — LLM orchestrator + MCP hub
+│   ├── components/       @burnishdev/components — 10 Lit web components
+│   ├── renderer/         @burnishdev/renderer  — streaming parser + sanitizer
+│   ├── app/              @burnishdev/app — drill-down logic + stream orchestration
+│   └── server/           @burnishdev/server — LLM orchestrator + MCP hub
 ├── apps/
 │   └── demo/
 │       ├── server/       Hono API + dual-mode routing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,10 +32,10 @@ Alternatively, contact the maintainer directly via GitHub: [@danfking](https://g
 
 This security policy covers:
 
-- `@burnish/components` — web component library
-- `@burnish/renderer` — streaming HTML parser and sanitizer
-- `@burnish/server` — MCP hub and LLM orchestrator
-- `@burnish/app` — headless SDK
+- `@burnishdev/components` — web component library
+- `@burnishdev/renderer` — streaming HTML parser and sanitizer
+- `@burnishdev/server` — MCP hub and LLM orchestrator
+- `@burnishdev/app` — headless SDK
 - `burnish` CLI
 
 **Out of scope**: Third-party MCP servers connected via Burnish. Security issues with MCP servers should be reported to their respective maintainers.

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -11,10 +11,10 @@
     "clean": "echo 'nothing to clean'"
   },
   "dependencies": {
-    "@burnish/app": "workspace:*",
-    "@burnish/components": "workspace:*",
-    "@burnish/renderer": "workspace:*",
-    "@burnish/server": "workspace:*",
+    "@burnishdev/app": "workspace:*",
+    "@burnishdev/components": "workspace:*",
+    "@burnishdev/renderer": "workspace:*",
+    "@burnishdev/server": "workspace:*",
     "@hono/node-server": "^1.14.0",
     "hono": "^4.7.0"
   },

--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -24,7 +24,7 @@ import {
     generateSummary, formatTimeAgo,
     TemplateStore, deriveToolKey,
     PromptLibrary,
-} from '@burnish/app';
+} from '@burnishdev/app';
 
 // ── Template learning ──
 import { recordPositiveSignal, getTemplateInstructions } from './template-learning.js';

--- a/apps/demo/public/components/index.js
+++ b/apps/demo/public/components/index.js
@@ -1,4 +1,4 @@
-// @burnish/components — Lit web components for rendering MCP tool call results
+// @burnishdev/components — Lit web components for rendering MCP tool call results
 export { BurnishCard } from './card.js';
 export { BurnishStatBar } from './stat-bar.js';
 export { BurnishTable } from './table.js';

--- a/apps/demo/public/copilot-ui.js
+++ b/apps/demo/public/copilot-ui.js
@@ -8,7 +8,7 @@
  */
 
 import { escapeAttr } from './shared.js';
-import { transformOutput } from '@burnish/app';
+import { transformOutput } from '@burnishdev/app';
 
 let currentMode = localStorage.getItem('burnish:mode') || 'explorer';
 let copilotAvailable = false;

--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -9,7 +9,7 @@ import { recordToolPerf, refreshPerfPanel } from './perf-panel.js';
 import { getTemplateInstructions } from './template-learning.js';
 import { appendAmbientSuggestions } from './ambient-suggestions.js';
 
-// ── Inline risk assessment (mirrors @burnish/app risk-indicators.ts) ──
+// ── Inline risk assessment (mirrors @burnishdev/app risk-indicators.ts) ──
 
 const HIGH_RISK_RE = /^(delete|drop|remove|destroy|push|force)[_-]/i;
 const MEDIUM_RISK_RE = /^(create|update|write|set|modify|send)[_-]/i;

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -19,10 +19,10 @@
             "@lit/reactive-element": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@2/+esm",
             "@lit/reactive-element/": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@2/",
             "idb-keyval": "https://cdn.jsdelivr.net/npm/idb-keyval@6/+esm",
-            "@burnish/app": "/app/index.js",
-            "@burnish/app/": "/app/",
-            "@burnish/renderer": "/renderer/index.js",
-            "@burnish/renderer/": "/renderer/"
+            "@burnishdev/app": "/app/index.js",
+            "@burnishdev/app/": "/app/",
+            "@burnishdev/renderer": "/renderer/index.js",
+            "@burnishdev/renderer/": "/renderer/"
         }
     }
     </script>

--- a/apps/demo/public/perf-panel.js
+++ b/apps/demo/public/perf-panel.js
@@ -3,7 +3,7 @@
  * Accessible via the chart icon in the header toolbar.
  */
 
-import { PerfStore } from '@burnish/app';
+import { PerfStore } from '@burnishdev/app';
 import { escapeHtml } from './shared.js';
 
 const perfStore = new PerfStore();

--- a/apps/demo/public/template-learning.js
+++ b/apps/demo/public/template-learning.js
@@ -3,7 +3,7 @@
  * positively-rated responses and injecting proven templates.
  */
 
-import { TemplateStore, extractHtmlStructure, deriveToolKey } from '@burnish/app';
+import { TemplateStore, extractHtmlStructure, deriveToolKey } from '@burnishdev/app';
 
 /** Singleton template store instance */
 const templateStore = new TemplateStore();

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -25,7 +25,7 @@ import {
     ConversationStore,
     LlmOrchestrator,
     ALLOWED_MODELS,
-} from '@burnish/server';
+} from '@burnishdev/server';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = new Hono();
@@ -53,7 +53,7 @@ function detectBackend(): 'api' | 'cli' | 'openai' | 'none' {
 
 const llmBackend = detectBackend();
 
-// --- Instantiate @burnish/server classes ---
+// --- Instantiate @burnishdev/server classes ---
 const mcpHub = new McpHub();
 const conversations = llmBackend !== 'none' ? new ConversationStore(1000) : null;
 const llm = llmBackend !== 'none' ? new LlmOrchestrator(mcpHub, conversations!) : null;
@@ -458,7 +458,7 @@ const CACHE_BUSTER = `v=${Date.now()}`;
 const repoRoot = resolve(__dirname, '../../..');
 const demoRoot = resolve(__dirname, '..');
 
-// Serve @burnish/app dist files
+// Serve @burnishdev/app dist files
 app.get('/app/:file{.+}', async (c) => {
     const baseDir = resolve(repoRoot, 'packages/app/dist');
     const filePath = safePath(baseDir, c.req.param('file'));
@@ -474,7 +474,7 @@ app.get('/app/:file{.+}', async (c) => {
     }
 });
 
-// Serve @burnish/renderer dist files
+// Serve @burnishdev/renderer dist files
 app.get('/renderer/:file{.+}', async (c) => {
     const baseDir = resolve(repoRoot, 'packages/renderer/dist');
     const filePath = safePath(baseDir, c.req.param('file'));

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@burnish/app",
+  "name": "@burnishdev/app",
   "version": "0.1.0",
   "description": "Headless SDK for Burnish — navigation, sessions, streaming, and output transformation",
   "type": "module",

--- a/packages/app/src/drill-down.ts
+++ b/packages/app/src/drill-down.ts
@@ -2,7 +2,7 @@
  * Drill-down helpers — prompt generation and write-tool detection.
  */
 
-// NOTE: Intentionally duplicated from @burnish/server/guards.ts for runtime isolation
+// NOTE: Intentionally duplicated from @burnishdev/server/guards.ts for runtime isolation
 // (this package runs in the browser, server runs in Node)
 const WRITE_TOOL_PATTERNS = /^(create|update|delete|remove|push|write|edit|move|fork|merge|add|set|close|lock|assign)/i;
 

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,4 +1,4 @@
-// @burnish/app — headless SDK for navigation, sessions, and output transformation
+// @burnishdev/app — headless SDK for navigation, sessions, and output transformation
 
 export {
     getNodeById,

--- a/packages/app/src/risk-indicators.ts
+++ b/packages/app/src/risk-indicators.ts
@@ -121,7 +121,7 @@ export interface ConfigWarning {
 
 /**
  * Shape of a single MCP server entry in the config file.
- * Mirrors McpServerConfig from @burnish/server but kept local to avoid
+ * Mirrors McpServerConfig from @burnishdev/server but kept local to avoid
  * a cross-package dependency — the app package must stay framework-agnostic.
  */
 interface ServerConfigEntry {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "clean": "rm -rf dist assets"
   },
   "dependencies": {
-    "@burnish/server": "workspace:*",
+    "@burnishdev/server": "workspace:*",
     "@hono/node-server": "^1.14.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "hono": "^4.7.0",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -6,7 +6,7 @@
 import { writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { McpServersConfig } from '@burnish/server';
+import type { McpServersConfig } from '@burnishdev/server';
 import type { CliOptions } from './cli.js';
 
 let _tmpDir: string | null = null;

--- a/packages/cli/src/export.ts
+++ b/packages/cli/src/export.ts
@@ -2,7 +2,7 @@
  * Export MCP server schema as JSON to stdout.
  */
 
-import { McpHub } from '@burnish/server';
+import { McpHub } from '@burnishdev/server';
 import { buildConfigFile, cleanupTempConfig } from './config.js';
 import type { CliOptions } from './cli.js';
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,7 @@
  *
  * @example
  * ```ts
- * import { McpHub } from '@burnish/server';
+ * import { McpHub } from '@burnishdev/server';
  * import { startServerWithHub, buildApp } from 'burnish';
  *
  * const hub = new McpHub();

--- a/packages/cli/src/middleware.ts
+++ b/packages/cli/src/middleware.ts
@@ -19,7 +19,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 
-import { McpHub } from '@burnish/server';
+import { McpHub } from '@burnishdev/server';
 import { startServerWithHub, type ServerOptions } from './server.js';
 
 /**

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 import open from 'open';
 
-import { McpHub, isWriteTool } from '@burnish/server';
+import { McpHub, isWriteTool } from '@burnishdev/server';
 import { buildConfigFile, cleanupTempConfig } from './config.js';
 import type { CliOptions } from './cli.js';
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@burnish/components",
+  "name": "@burnishdev/components",
   "version": "0.1.0",
   "description": "Lit web components for rendering MCP tool call results",
   "type": "module",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,4 @@
-// @burnish/components — Lit web components for rendering MCP tool call results
+// @burnishdev/components — Lit web components for rendering MCP tool call results
 
 export { BurnishCard } from './card.js';
 export { BurnishStatBar } from './stat-bar.js';

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@burnish/renderer",
+  "name": "@burnishdev/renderer",
   "version": "0.1.0",
   "description": "Streaming HTML renderer and component mapper for Burnish",
   "type": "module",

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1,4 +1,4 @@
-// @burnish/renderer — render engine for MCP UI
+// @burnishdev/renderer — render engine for MCP UI
 
 export {
     buildSanitizerConfig,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@burnish/server",
+  "name": "@burnishdev/server",
   "version": "0.1.0",
   "description": "MCP orchestration, LLM streaming, and session management for Burnish",
   "type": "module",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-// @burnish/server — MCP orchestration and session management
+// @burnishdev/server — MCP orchestration and session management
 
 // ConversationStore is used by LlmOrchestrator in Copilot mode
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,16 +17,16 @@ importers:
 
   apps/demo:
     dependencies:
-      '@burnish/app':
+      '@burnishdev/app':
         specifier: workspace:*
         version: link:../../packages/app
-      '@burnish/components':
+      '@burnishdev/components':
         specifier: workspace:*
         version: link:../../packages/components
-      '@burnish/renderer':
+      '@burnishdev/renderer':
         specifier: workspace:*
         version: link:../../packages/renderer
-      '@burnish/server':
+      '@burnishdev/server':
         specifier: workspace:*
         version: link:../../packages/server
       '@hono/node-server':
@@ -57,7 +57,7 @@ importers:
 
   packages/cli:
     dependencies:
-      '@burnish/server':
+      '@burnishdev/server':
         specifier: workspace:*
         version: link:../server
       '@hono/node-server':


### PR DESCRIPTION
## Summary
Closes #247

Renames all four scoped packages from `@burnish/*` to `@burnishdev/*` to match the npm org we have access to. The CLI package (`burnish`) is unchanged.

[skip-screenshot]

## Changes
- **Package names**: Updated `name` field in `packages/app`, `packages/components`, `packages/renderer`, and `packages/server`
- **Dependencies**: Updated all `@burnish/*` cross-references in `dependencies`/`devDependencies` across the monorepo (demo app, CLI)
- **Source imports**: Updated all TypeScript/JS import statements referencing `@burnish/*`
- **Import maps**: Updated browser import map in `apps/demo/public/index.html`
- **CI**: Updated publish workflow filter from `@burnish/*` to `@burnishdev/*`
- **Docs**: Updated references in README.md, CLAUDE.md, CONTRIBUTING.md, and SECURITY.md

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)