### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Burnish demo app — connects to MCP servers and renders visual dashboards",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "burnish",
+  "version": "0.1.1",
   "private": true,
   "description": "Universal UI layer for MCP servers",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Headless SDK for Burnish — navigation, sessions, streaming, and output transformation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Swagger UI for MCP servers — explore, test, and visualize any MCP server",
   "type": "module",
   "bin": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lit web components for rendering MCP tool call results",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/renderer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Streaming HTML renderer and component mapper for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP orchestration, LLM streaming, and session management for Burnish",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump all package versions from 0.1.0 to 0.1.1 since burnish@0.1.0 was already published to npm.

## Changes

Updated the `version` field in all workspace packages:
- `package.json` (root) — added version 0.1.1
- `packages/app/package.json`
- `packages/cli/package.json`
- `packages/components/package.json`
- `packages/renderer/package.json`
- `packages/server/package.json`
- `apps/demo/package.json`

[skip-screenshot]

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)