### PR TITLE
docs: remove stale npm publish disclaimers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@
 ```bash
 npx burnish -- npx @modelcontextprotocol/server-filesystem /tmp
 ```
-
-> `npx burnish` is not yet published to npm — use [git clone](#from-source) for now.
-
 ---
 
 ## What is Burnish?
@@ -52,8 +49,6 @@ npx burnish -- npx @modelcontextprotocol/server-filesystem /tmp
 # LLM Insight — with LLM
 npx burnish --llm=cli -- npx @modelcontextprotocol/server-filesystem /tmp
 ```
-
-> Not yet available via npx — packages are pending npm publish. Use the git clone method below.
 
 ### From source
 
@@ -166,8 +161,6 @@ await withBurnishUI(server, { port: 3001 });
 npx burnish export -- npx @your-org/your-server > schema.json
 ```
 
-> SDK packages are not yet published to npm — this section describes the planned API.
-
 ## Recipes
 
 Multi-server combinations that show Burnish at its best. Each recipe is a `mcp-servers.json` config plus a prompt.
@@ -253,8 +246,6 @@ Connect web search + filesystem. Search, summarize, save.
 
 ### CDN (no build step)
 
-> Available after npm publish. The CDN URLs below will work once packages are released.
-
 ```html
 <script type="module"
   src="https://cdn.jsdelivr.net/npm/@burnishdev/components/dist/index.js"></script>
@@ -272,8 +263,6 @@ Connect web search + filesystem. Search, summarize, save.
 
 ### npm
 
-> Available after npm publish.
-
 ```bash
 npm install @burnishdev/components
 ```
@@ -288,8 +277,6 @@ customElements.define('my-card', class extends BurnishCard {});
 ```
 
 ### Renderer
-
-> Available after npm publish.
 
 ```bash
 npm install @burnishdev/renderer


### PR DESCRIPTION
## Summary
Closes #269

## Fix / Changes
Removed 6 stale disclaimer lines from README.md that stated packages were "not yet published to npm." All packages except @burnishdev/cli are now live on npm at v0.1.1, making these disclaimers inaccurate.

Removed lines:
1. `npx burnish` not yet published disclaimer (after hero snippet)
2. "Not yet available via npx" under Quick Start
3. "SDK packages are not yet published" in SDK section
4. "Available after npm publish" in CDN section
5. "Available after npm publish" in npm install section
6. "Available after npm publish" in Renderer section

No other content was changed.

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)