### PR TITLE
chore(ci): fix publish.yml echo message to reference @burnishdev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish scoped packages (@burnishdev/*)
-        run: pnpm --filter '@burnishdev/*' publish --no-git-checks --access public || echo "Scoped packages skipped — @burnish org may not exist yet"
+        run: pnpm --filter '@burnishdev/*' publish --no-git-checks --access public || echo "Scoped packages skipped — @burnishdev publish may have failed"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Closes #253

The publish CI workflow's fallback echo message referenced `@burnish` instead of the actual npm scope `@burnishdev`. The message also incorrectly implied the org might not exist.

## Fix
Updated the echo message in `.github/workflows/publish.yml` from:
```
Scoped packages skipped — @burnish org may not exist yet
```
to:
```
Scoped packages skipped — @burnishdev publish may have failed
```

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)