### PR TITLE
fix(components): style form inputs for dark mode theme

### DIFF
--- a/packages/components/src/table.ts
+++ b/packages/components/src/table.ts
@@ -30,8 +30,10 @@ export class BurnishTable extends LitElement {
             font-size: var(--burnish-font-size-md, 14px); font-weight: 600;
         }
         .table-search {
-            padding: 5px 10px; border: 1px solid var(--burnish-border, #E5DDDD);
+            padding: 5px 10px; border: 1px solid var(--burnish-input-border, var(--burnish-border, #E5DDDD));
             border-radius: 4px; font-size: 12px; min-width: 150px; outline: none;
+            background: var(--burnish-input-bg, var(--burnish-surface, #fff));
+            color: var(--burnish-text, #2D1F1F); font-family: inherit;
         }
         .table-search:focus { border-color: var(--burnish-accent, #8B3A3A); }
         table { width: 100%; border-collapse: collapse; font-size: var(--burnish-font-size-base, 13px); }
@@ -73,13 +75,16 @@ export class BurnishTable extends LitElement {
         .table-pagination { display: flex; align-items: center; gap: 6px; }
         .page-btn {
             padding: 3px 8px; border: 1px solid var(--burnish-border, #E5DDDD);
-            border-radius: 3px; background: none; cursor: pointer; font-size: 12px;
+            border-radius: 3px; background: var(--burnish-surface, #fff); cursor: pointer;
+            font-size: 12px; color: var(--burnish-text, #2D1F1F);
         }
         .page-btn:hover:not(:disabled) { background: var(--burnish-surface-alt, #F8F5F5); }
         .page-btn:disabled { opacity: 0.3; cursor: not-allowed; }
         .page-size-select {
-            padding: 2px 4px; border: 1px solid var(--burnish-border, #E5DDDD);
-            border-radius: 3px; font-size: 11px; background: none;
+            padding: 2px 4px; border: 1px solid var(--burnish-input-border, var(--burnish-border, #E5DDDD));
+            border-radius: 3px; font-size: 11px;
+            background: var(--burnish-input-bg, var(--burnish-surface, #fff));
+            color: var(--burnish-text, #2D1F1F); font-family: inherit;
         }
         .no-results {
             padding: 24px 16px; text-align: center;


### PR DESCRIPTION
## Summary
Fixes #283

Form inputs in `burnish-table` (filter input, page-size select, pagination buttons) retained white/transparent backgrounds in dark mode instead of adapting to the dark theme. The `burnish-form` component already used the correct `--burnish-input-bg` and `--burnish-input-border` tokens and was not affected.

## Root Cause
The table component's `.table-search` input, `.page-size-select` dropdown, and `.page-btn` buttons used hardcoded `background: none` or had no explicit background/color set. Since these elements are in shadow DOM, they don't inherit the host page's dark mode overrides for native form controls, resulting in white inputs on a dark surface.

## Fix
Updated the table component's CSS to use the existing `--burnish-input-bg`, `--burnish-input-border`, `--burnish-surface`, and `--burnish-text` design tokens (already defined with dark mode values in `tokens.css`):

- `.table-search`: Added `background`, `color`, `font-family` and switched border to use `--burnish-input-border`
- `.page-size-select`: Added `background`, `color`, `font-family` and switched border to use `--burnish-input-border`
- `.page-btn`: Changed `background: none` to `background: var(--burnish-surface)` and added `color`

No changes to `form.ts` were needed as it already used the correct tokens.

## Verification
**Light mode:**
![verify-283-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-283-light-20260409090702.png)
**Dark mode:**
![verify-283-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-283-dark-20260409090702.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification confirms form inputs adapt to dark mode
- [x] Light mode appearance unchanged (tokens have correct fallback values)