### PR TITLE
fix(demo): fix session switching, breadcrumb, and LLM mode toggle

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -166,8 +166,12 @@ async function switchSession(sessionId) {
 
     // Lazy-load nodes if not yet loaded
     const session = getActiveSession();
-    if (session && !persistence.isLoaded(session.id) && session._nodeIds) {
-        await persistence.loadNodes(session, session._nodeIds);
+    if (session && !persistence.isLoaded(session.id)) {
+        const nodeIds = session._nodeIds
+            || await persistence.getSessionNodeIds(session.id);
+        if (nodeIds && nodeIds.length > 0) {
+            await persistence.loadNodes(session, nodeIds);
+        }
         delete session._nodeIds;
         persistence.markLoaded(session.id);
     }
@@ -222,6 +226,11 @@ function updateBreadcrumb() {
     let pathNodes = [];
     if (session.activeNodeId) {
         pathNodes = getAncestryPath(session, session.activeNodeId);
+    }
+
+    // Skip the root node — it duplicates the session title segment
+    if (pathNodes.length > 0 && !pathNodes[0].parentId) {
+        pathNodes = pathNodes.slice(1);
     }
 
     const segments = [];
@@ -369,6 +378,7 @@ function createNodeEl(node) {
     div.className = 'burnish-node';
     div.dataset.nodeId = node.id;
     div.dataset.collapsed = String(node.collapsed);
+    if (node._executionMode) div.dataset.executionMode = node._executionMode;
 
     const statsParts = [];
     if (node.summary) statsParts.push(node.summary);
@@ -688,6 +698,13 @@ function renderMainContent() {
 
     for (const root of roots) {
         renderTreeNode(treeWrapper, session, root, activePath);
+    }
+
+    // Hide LLM-generated nodes when in explorer mode
+    if (getCurrentMode() !== 'llm-insight') {
+        treeWrapper.querySelectorAll('.burnish-node[data-execution-mode="llm-insight"]').forEach(el => {
+            el.style.display = 'none';
+        });
     }
 
     if (session.activeNodeId) {

--- a/apps/demo/public/llm-insight-ui.js
+++ b/apps/demo/public/llm-insight-ui.js
@@ -65,6 +65,13 @@ export function renderModeToggle(container) {
             // Toggle prompt bar visibility
             const promptBar = document.getElementById('llm-insight-prompt-bar');
             if (promptBar) promptBar.style.display = currentMode === 'llm-insight' ? 'flex' : 'none';
+            // Hide/show LLM-generated nodes based on mode
+            const dashboard = document.getElementById('dashboard-container');
+            if (dashboard) {
+                dashboard.querySelectorAll('.burnish-node[data-execution-mode="llm-insight"]').forEach(el => {
+                    el.style.display = currentMode === 'llm-insight' ? '' : 'none';
+                });
+            }
         });
     });
 }


### PR DESCRIPTION
## Summary
Fixes #304, #301, #302, #303

Four session/navigation bugs:
- **#304**: Session switching properly restores content (await IndexedDB load)
- **#301**: Breadcrumb no longer duplicates the root node
- **#302/#303**: LLM results clear when switching to Explorer mode

## Root Cause
- #304: switchSession() rendered before async IndexedDB node load completed
- #301: getAncestryPath() returned root node, duplicating the session title segment
- #302/#303: Mode toggle didn't hide LLM-generated nodes

## Changes
- app.js: switchSession() falls back to persistence.getSessionNodeIds(); updateBreadcrumb() skips root; createNodeEl() tags nodes with data-execution-mode; renderMainContent() hides LLM nodes in explorer mode
- llm-insight-ui.js: Mode toggle shows/hides LLM-tagged nodes

## Verification

**Light mode -- Main view with Filesystem server connected:**
![verify-337-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-337-light-20260410082022.png)

**Breadcrumb after navigation into server (no duplication -- shows "Burnish > filesystem tools"):**
![verify-337-breadcrumb](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-337-breadcrumb-20260410082022.png)

**Dark mode -- Filesystem server tools view:**
![verify-337-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-337-dark-20260410082022.png)

**Session restore -- switched away and back, content fully restored (#304):**
![verify-337-session-restore](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-337-session-restore-20260410082022.png)

## Test Plan
- [x] pnpm build passes
- [ ] CI tests pass
- [ ] Manual: switch sessions, verify content loads; check breadcrumb; toggle LLM/Explorer modes