### PR TITLE
fix(demo): improve data rendering for edge cases

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -454,7 +454,7 @@ async function regenerateNode(nodeId) {
                 });
                 const data = await res.json();
                 if (res.ok) {
-                    const resultHtml = buildResultHtml(data.result, node.promptDisplay, node._toolCall.toolName);
+                    const resultHtml = buildResultHtml(data.result, node.promptDisplay, node._toolCall.toolName, undefined, data.isError);
                     node.response = resultHtml;
                     node.type = 'components';
                     const contentEl = document.querySelector(`[data-node-id="${nodeId}"] .burnish-node-content`);
@@ -1170,7 +1170,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     .map(([, v]) => v)
                     .join(', ');
                 const displayLabel = keyValues ? `${toolShortName}: ${keyValues}` : toolShortName;
-                const resultHtml = buildResultHtml(data.result, displayLabel, toolId);
+                const resultHtml = buildResultHtml(data.result, displayLabel, toolId, undefined, data.isError);
                 recordToolPerf({ toolName: toolId, latencyMs: 0, responseHtml: resultHtml });
                 refreshPerfPanel();
                 const writeNode = renderDeterministicNode(displayLabel, resultHtml);
@@ -1238,7 +1238,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             renderMainContent();
 
-            const resultHtml = buildResultHtml(data.result, displayLabel, toolId);
+            const resultHtml = buildResultHtml(data.result, displayLabel, toolId, undefined, data.isError);
             recordToolPerf({ toolName: toolId, latencyMs: data.durationMs || 0, responseHtml: resultHtml });
             refreshPerfPanel();
             node.response = resultHtml;

--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -194,7 +194,7 @@ export async function executeToolDirect(toolName, args, label) {
         });
         var data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Execution failed');
-        var resultHtml = buildResultHtml(data.result, label, toolName, data.serverName);
+        var resultHtml = buildResultHtml(data.result, label, toolName, data.serverName, data.isError);
         var contentEl = node ? document.querySelector('[data-node-id="' + node.id + '"] .burnish-node-content') : null;
         if (contentEl) {
             contentEl.innerHTML = DOMPurify.sanitize(resultHtml, PURIFY_CONFIG);

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -73,7 +73,9 @@ export function renderCardsView(items, sourceToolName, dataId, sourceName) {
     let html = '<div class="burnish-cards-grid">';
     for (let i = 0; i < Math.min(items.length, 50); i++) {
         const item = items[i];
-        const title = item.full_name || item.name || item.title || item.login || 'Item';
+        // #313: Include message/sha/commit.message for commit objects
+        const title = item.full_name || item.name || item.title || item.message
+            || (item.commit && item.commit.message) || item.sha || item.login || 'Item';
         const rawBody = item.description || item.body || item.message || '';
         const body = stripMarkdown(rawBody).substring(0, 150);
         const status = inferCardStatus(item, sourceToolName);
@@ -176,9 +178,15 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
             }
             return html;
         }
-        return parsed.slice(0, 20).map(item =>
-            `<burnish-card title="${escapeAttr(String(item))}" status="info"${sourceAttr}></burnish-card>`
-        ).join('');
+        // #336: Render primitive arrays (e.g. directory paths) as a list card
+        const listBody = parsed.slice(0, 50).map(item => `- ${String(item)}`).join('\n');
+        return `<burnish-card title="${escapeAttr(label)}" status="info" body="${escapeAttr(listBody)}"${sourceAttr}></burnish-card>`;
+    }
+
+    // #314: Plain string content — render directly as a card body
+    if (typeof parsed === 'string') {
+        const body = parsed.substring(0, 2000) || '(empty)';
+        return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(body)}"${sourceAttr}></burnish-card>`;
     }
 
     if (typeof parsed === 'object' && parsed !== null) {
@@ -201,11 +209,13 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
             return html;
         }
 
+        // #335: Infer a meaningful title from the object, and show ALL scalar fields
+        const titleFields = ['name', 'path', 'filename', 'title', 'full_name', 'login', 'label'];
+        const inferredTitle = titleFields.reduce((acc, k) => acc || (parsed[k] ? String(parsed[k]) : ''), '') || label;
         const meta = Object.entries(parsed)
             .filter(([, v]) => (typeof v !== 'object' || v === null) && typeof v !== 'boolean')
-            .slice(0, 10)
             .map(([k, v]) => ({ label: k.replace(/_/g, ' '), value: String(v ?? '') }));
-        return `<burnish-card title="${escapeAttr(label)}" status="success" meta='${escapeAttr(JSON.stringify(meta))}'${sourceAttr}></burnish-card>`;
+        return `<burnish-card title="${escapeAttr(inferredTitle)}" status="success" meta='${escapeAttr(JSON.stringify(meta))}'${sourceAttr}></burnish-card>`;
     }
 
     return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(String(parsed))}"${sourceAttr}></burnish-card>`;
@@ -354,7 +364,13 @@ function tryParseDirectoryListing(result, label) {
     return html;
 }
 
-export function buildResultHtml(result, label, sourceToolName, sourceName) {
+export function buildResultHtml(result, label, sourceToolName, sourceName, isError) {
+    // #329: If MCP flagged this as an error, render an error card
+    if (isError) {
+        const sourceAttr = sourceName ? ` source="${escapeAttr(sourceName)}"` : '';
+        return `<burnish-card title="Error" status="error" body="${escapeAttr(String(result).substring(0, 2000))}"${sourceAttr}></burnish-card>`;
+    }
+
     try {
         const parsed = JSON.parse(result);
         const inner = renderParsedResult(parsed, label, sourceToolName, sourceName);


### PR DESCRIPTION
## Summary\nFixes #329, #314, #335, #336, #313\n\nAddresses 5 data rendering issues found during exploratory testing:\n- **#329**: Invalid paths now show ERROR cards instead of SUCCESS (checks MCP `isError` flag)\n- **#314**: Plain string content (like file contents) renders properly in cards\n- **#335**: Single-object results show all metadata fields with smart title inference\n- **#336**: String arrays (like directory listings) render as list cards\n- **#313**: Commit cards show commit messages instead of generic \"Item\" title\n\n## Root Cause\n`view-renderers.js` had gaps in its type handling: no error flag check, no plain-string path, truncated metadata fields, broken primitive array branch, and limited title inference.\n\n## Changes\n- `buildResultHtml()`: Added `isError` parameter; renders error card when MCP result has `isError: true`\n- `renderParsedResult()`: Added string-type branch rendering content as card body\n- Single-object rendering: Extended title inference priority list; removed `.slice(0,10)` field cap\n- Primitive array branch: Renders as single card with markdown list\n- `renderCardsView()`: Added `message`, `commit.message`, `sha` to title inference chain\n\n## Verification\n**Light mode:**\n![verify-339-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-339-light-20260410081415.png)\n**Dark mode:**\n![verify-339-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-339-dark-20260410081415.png)\n\nScreenshots demonstrate all 5 fixes with injected mock data:\n1. **Error card** (#329) — Red border and ERROR badge for ENOENT error\n2. **String content** (#314) — Config file text rendered in a card body\n3. **Full metadata** (#335) — package.json with all 10 fields displayed\n4. **String array** (#336) — Directory paths as a bulleted list card\n5. **Commit titles** (#313) — Commit messages shown as card titles with sha metadata\n\n## Test Plan\n- [x] `pnpm build` passes\n- [ ] CI tests pass\n- [x] Visual verification screenshots confirm rendering improvements in both themes