### PR TITLE
style(demo): visual polish — favicon, card layout, mobile UX, markdown rendering

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -380,7 +380,7 @@ function createNodeEl(node) {
             <span class="burnish-node-prompt">${escapeHtml(node.promptDisplay || node.prompt)}</span>
             <span class="burnish-node-time">${formatTimeAgo(node.timestamp)}</span>
             ${node._executionMode === 'deterministic' ? `<span class="burnish-exec-badge burnish-exec-badge--direct" title="No LLM — direct tool execution">Direct</span>` : ''}
-            ${statsTooltip ? `<button class="burnish-node-info" title="${escapeAttr(statsTooltip)}">
+            ${statsTooltip ? `<button class="burnish-node-info" title="View details">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>
             </button>` : ''}
             <button class="burnish-node-maximize" title="Focus">
@@ -613,13 +613,13 @@ function updateNodeHeader(nodeId) {
 
     const infoBtn = el.querySelector('.burnish-node-info');
     if (infoBtn) {
-        infoBtn.title = parts.join(' \u2022 ');
+        infoBtn.title = 'View details';
     } else if (parts.length > 0) {
         const deleteBtn = el.querySelector('.burnish-node-delete');
         if (deleteBtn) {
             const btn = document.createElement('button');
             btn.className = 'burnish-node-info';
-            btn.title = parts.join(' \u2022 ');
+            btn.title = 'View details';
             btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>';
             btn.addEventListener('click', (e) => {
                 e.stopPropagation();
@@ -790,10 +790,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (item) switchSession(item.dataset.sessionId);
     });
 
-    // Mobile toggle for session panel
-    document.getElementById('btn-toggle-sessions')?.addEventListener('click', () => {
-        document.getElementById('session-panel')?.classList.toggle('open');
-    });
+    // Mobile toggle for session panel with backdrop
+    const sessionPanel = document.getElementById('session-panel');
+    const sidebarBackdrop = document.getElementById('sidebar-backdrop');
+    function toggleSidebar() {
+        const isOpen = sessionPanel?.classList.toggle('open');
+        sidebarBackdrop?.classList.toggle('visible', isOpen);
+    }
+    function closeSidebar() {
+        sessionPanel?.classList.remove('open');
+        sidebarBackdrop?.classList.remove('visible');
+    }
+    document.getElementById('btn-toggle-sessions')?.addEventListener('click', toggleSidebar);
+    sidebarBackdrop?.addEventListener('click', closeSidebar);
 
     // ── Restore from IndexedDB ──
     const state = await loadState();

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Burnish — Universal MCP Dashboard</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath d='M16 2l4 10h10l-8 6 3 10-9-7-9 7 3-10-8-6h10z' fill='%238B3A3A'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="/tokens.css">
     <link rel="stylesheet" href="/style.css">
 
@@ -68,6 +69,9 @@
     <script type="module" src="/app.js"></script>
 </head>
 <body>
+    <!-- Sidebar backdrop (mobile) -->
+    <div id="sidebar-backdrop" class="burnish-sidebar-backdrop"></div>
+
     <!-- Session Panel (left) -->
     <aside id="session-panel" class="burnish-session-panel">
         <div class="burnish-session-panel-header">
@@ -142,7 +146,7 @@
 
     <!-- LLM Insight prompt bar (hidden unless LLM Insight mode active) -->
     <div id="llm-insight-prompt-bar">
-        <input type="text" placeholder="Ask a question in natural language..." id="llm-insight-input">
+        <textarea rows="1" placeholder="Ask a question in natural language..." id="llm-insight-input"></textarea>
     </div>
 
 </body>

--- a/apps/demo/public/llm-insight-ui.js
+++ b/apps/demo/public/llm-insight-ui.js
@@ -126,13 +126,24 @@ export function initPromptBar(PURIFY_CONFIG, sessionHelpers) {
     // Show/hide based on mode
     promptBar.style.display = currentMode === 'llm-insight' ? 'flex' : 'none';
 
+    // Auto-resize textarea to fit content
+    function autoResize() {
+        input.style.height = 'auto';
+        input.style.height = Math.min(input.scrollHeight, 200) + 'px';
+    }
+    input.addEventListener('input', autoResize);
+
     input.addEventListener('keydown', async (e) => {
+        // Allow Shift+Enter for newlines
+        if (e.key === 'Enter' && e.shiftKey) return;
         if (e.key !== 'Enter' || isStreaming) return;
+        e.preventDefault();
 
         const prompt = input.value.trim();
         if (!prompt) return;
 
         input.value = '';
+        autoResize();
         const pivot = isPivotCommand(prompt);
 
         await submitLlmInsightPrompt(prompt, PURIFY_CONFIG, sessionHelpers, pivot);

--- a/apps/demo/public/llm-insight-ui.js
+++ b/apps/demo/public/llm-insight-ui.js
@@ -52,8 +52,14 @@ export function renderModeToggle(container) {
     container.style.display = '';
     container.innerHTML = `
         <div class="burnish-mode-toggle">
-            <button class="burnish-mode-btn ${currentMode === 'explorer' ? 'active' : ''}" data-mode="explorer">Explorer</button>
-            <button class="burnish-mode-btn ${currentMode === 'llm-insight' ? 'active' : ''}" data-mode="llm-insight">LLM Insight</button>
+            <button class="burnish-mode-btn ${currentMode === 'explorer' ? 'active' : ''}" data-mode="explorer">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+                <span class="burnish-mode-label">Explorer</span>
+            </button>
+            <button class="burnish-mode-btn ${currentMode === 'llm-insight' ? 'active' : ''}" data-mode="llm-insight">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.1-.9 2-2 2h-4c-1.1 0-2-.9-2-2a4 4 0 0 1 4-4z"/><path d="M12 8v8"/><path d="M8 12h8"/><circle cx="12" cy="20" r="2"/></svg>
+                <span class="burnish-mode-label">LLM Insight</span>
+            </button>
         </div>
     `;
     container.querySelectorAll('.burnish-mode-btn').forEach(btn => {

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1099,21 +1099,53 @@ body {
     50% { opacity: 0.4; }
 }
 
+/* ── Mode Toggle ── */
+.burnish-mode-toggle {
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--burnish-surface-alt, #F0EAEA);
+    border-radius: 6px;
+}
+.burnish-mode-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 12px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    font-size: 12px;
+    cursor: pointer;
+    color: var(--burnish-text-secondary, #6B5A5A);
+    transition: all 0.15s ease;
+    white-space: nowrap;
+}
+.burnish-mode-btn.active {
+    background: var(--burnish-surface, #fff);
+    color: var(--burnish-text, #2D1F1F);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+/* ── Sidebar Backdrop (mobile overlay) ── */
+.burnish-sidebar-backdrop {
+    display: none;
+    position: fixed;
+    top: 48px;
+    left: 0;
+    width: 100%;
+    height: calc(100% - 48px);
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 4;
+}
+.burnish-sidebar-backdrop.visible { display: block; }
+
 /* ── Responsive ── */
 @media (max-width: 1024px) {
     .burnish-session-panel { left: -260px; transition: left var(--burnish-transition-normal); }
     .burnish-session-panel.open { left: 0; }
     .burnish-content { margin-left: 0; }
     .burnish-mobile-only { display: flex; }
-    .burnish-sidebar-backdrop {
-        display: none;
-        position: fixed;
-        inset: 0;
-        top: 48px;
-        background: rgba(0, 0, 0, 0.4);
-        z-index: 4;
-    }
-    .burnish-sidebar-backdrop.visible { display: block; }
 }
 
 @media (max-width: 768px) {
@@ -1125,7 +1157,8 @@ body {
     .burnish-header-left { min-width: 0; overflow: hidden; gap: 6px; }
     .burnish-header-right { min-width: 0; overflow: hidden; gap: 2px; flex-shrink: 1; }
     .burnish-logo { font-size: 14px; letter-spacing: 0.5px; }
-    .burnish-mode-toggle { display: none; }
+    .burnish-mode-label { display: none; }
+    .burnish-mode-btn { padding: 4px 6px; }
     .burnish-breadcrumb { display: none; }
     .burnish-theme-toggle span { display: none; }
     .burnish-empty-state { padding: 40px 16px 40px; }
@@ -1164,30 +1197,6 @@ body {
     color: var(--burnish-text-muted, #9C8F8F);
     text-align: center;
     border-top: 1px solid var(--burnish-border, #E5DDDD);
-}
-
-/* ── Mode Toggle ── */
-.burnish-mode-toggle {
-    display: flex;
-    gap: 2px;
-    padding: 2px;
-    background: var(--burnish-surface-alt, #F0EAEA);
-    border-radius: 6px;
-}
-.burnish-mode-btn {
-    padding: 4px 12px;
-    border: none;
-    border-radius: 4px;
-    background: transparent;
-    font-size: 12px;
-    cursor: pointer;
-    color: var(--burnish-text-secondary, #6B5A5A);
-    transition: all 0.15s ease;
-}
-.burnish-mode-btn.active {
-    background: var(--burnish-surface, #fff);
-    color: var(--burnish-text, #2D1F1F);
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
 /* ── AI Insight Slot ── */

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -918,12 +918,41 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: var(--burnish-space-md, 12px);
 }
+.burnish-cards-grid > :only-child {
+    grid-column: 1 / -1;
+}
 .burnish-json-view {
     background: var(--burnish-surface-alt, #F8F5F5); padding: 16px; border-radius: 4px;
     font-size: 11px; font-family: var(--burnish-font-mono, 'SF Mono', monospace);
     overflow: auto; max-height: 500px; white-space: pre-wrap; word-break: break-all;
     border: 1px solid var(--burnish-border-light, #F0EAEA);
 }
+.burnish-markdown-content {
+    background: var(--burnish-surface, #fff);
+    padding: 16px 20px;
+    border-radius: var(--burnish-radius-md, 4px);
+    border: 1px solid var(--burnish-border-light, #F0EAEA);
+    font-size: 14px; line-height: 1.6; color: var(--burnish-text, #2D1F1F);
+    overflow-wrap: break-word; word-break: break-word;
+    max-height: 600px; overflow-y: auto;
+}
+.burnish-markdown-content h1, .burnish-markdown-content h2, .burnish-markdown-content h3 {
+    margin: 16px 0 8px; color: var(--burnish-text, #2D1F1F);
+}
+.burnish-markdown-content h1 { font-size: 20px; }
+.burnish-markdown-content h2 { font-size: 17px; }
+.burnish-markdown-content h3 { font-size: 15px; }
+.burnish-markdown-content p { margin: 0 0 8px; }
+.burnish-markdown-content code {
+    background: var(--burnish-surface-alt, #F8F5F5); padding: 1px 4px;
+    border-radius: 3px; font-size: 13px;
+}
+.burnish-markdown-content pre {
+    background: var(--burnish-surface-alt, #F8F5F5); padding: 12px;
+    border-radius: 4px; overflow-x: auto; font-size: 13px;
+}
+.burnish-markdown-content ul, .burnish-markdown-content ol { padding-left: 20px; margin: 8px 0; }
+.burnish-markdown-content a { color: var(--burnish-link, #7C3030); }
 
 /* ── Diagnostic Panel ── */
 .burnish-diagnostic-panel {
@@ -1076,6 +1105,15 @@ body {
     .burnish-session-panel.open { left: 0; }
     .burnish-content { margin-left: 0; }
     .burnish-mobile-only { display: flex; }
+    .burnish-sidebar-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        top: 48px;
+        background: rgba(0, 0, 0, 0.4);
+        z-index: 4;
+    }
+    .burnish-sidebar-backdrop.visible { display: block; }
 }
 
 @media (max-width: 768px) {
@@ -1083,11 +1121,13 @@ body {
 }
 
 @media (max-width: 480px) {
-    .burnish-header { padding: 0 8px; overflow: hidden; }
-    .burnish-header-left { min-width: 0; overflow: hidden; gap: 8px; }
-    .burnish-header-right { min-width: 0; overflow: hidden; gap: 4px; flex-shrink: 1; }
+    .burnish-header { padding: 0 6px; overflow: hidden; gap: 4px; }
+    .burnish-header-left { min-width: 0; overflow: hidden; gap: 6px; }
+    .burnish-header-right { min-width: 0; overflow: hidden; gap: 2px; flex-shrink: 1; }
+    .burnish-logo { font-size: 14px; letter-spacing: 0.5px; }
     .burnish-mode-toggle { display: none; }
     .burnish-breadcrumb { display: none; }
+    .burnish-theme-toggle span { display: none; }
     .burnish-empty-state { padding: 40px 16px 40px; }
     .burnish-empty-state h2 { font-size: 22px; }
     .burnish-server-buttons { flex-direction: column; align-items: center; }
@@ -1184,24 +1224,30 @@ body {
     display: none;
     z-index: 100;
 }
-#llm-insight-prompt-bar input {
+#llm-insight-prompt-bar textarea {
     width: 100%;
     padding: 10px 12px;
     border: 1px solid var(--burnish-border, #E5DDDD);
     border-radius: 8px;
     font-size: 14px;
+    font-family: inherit;
     outline: none;
     background: var(--burnish-input-bg, var(--burnish-surface, #fff));
     color: var(--burnish-text, #2D1F1F);
+    resize: none;
+    overflow: hidden;
+    min-height: 40px;
+    max-height: 200px;
+    line-height: 1.4;
 }
-#llm-insight-prompt-bar input:focus {
+#llm-insight-prompt-bar textarea:focus {
     border-color: var(--burnish-accent, #8B3A3A);
     box-shadow: 0 0 0 2px rgba(139, 58, 58, 0.1);
 }
-#llm-insight-prompt-bar input::placeholder {
+#llm-insight-prompt-bar textarea::placeholder {
     color: var(--burnish-muted, #9ca3af);
 }
-#llm-insight-prompt-bar input:disabled {
+#llm-insight-prompt-bar textarea:disabled {
     opacity: 0.6;
     cursor: not-allowed;
 }

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -365,6 +365,12 @@ export function buildResultHtml(result, label, sourceToolName, sourceName) {
         if (dirHtml) return dirHtml;
 
         const sourceAttr = sourceName ? ` source="${escapeAttr(sourceName)}"` : '';
+        // Render markdown files through marked if available
+        const isMarkdown = /\.md$/i.test(label);
+        if (isMarkdown && typeof window.marked !== 'undefined') {
+            const rendered = DOMPurify.sanitize(window.marked.parse(result.substring(0, 5000)), PURIFY_CONFIG);
+            return `<div class="burnish-result-wrapper"><div class="burnish-markdown-content">${rendered}</div></div>`;
+        }
         return `<burnish-card title="${escapeAttr(label)}" status="success" body="${escapeAttr(result.substring(0, 1000))}"${sourceAttr}></burnish-card>`;
     }
 }

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -75,6 +75,9 @@ export class BurnishCard extends LitElement {
             box-shadow: var(--burnish-shadow-sm);
             transition: transform var(--burnish-transition-fast), box-shadow var(--burnish-transition-fast);
             position: relative;
+            display: flex;
+            flex-direction: column;
+            height: 100%;
         }
         .card::before {
             content: '';
@@ -123,8 +126,10 @@ export class BurnishCard extends LitElement {
             font-size: var(--burnish-font-size-base, 13px); color: var(--burnish-text-secondary);
             line-height: 1.5;
             overflow-wrap: anywhere; word-break: break-word;
-            max-height: 120px;
-            overflow-y: auto;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
         }
         .card-body h1, .card-body h2, .card-body h3, .card-body h4 {
             font-size: 13px; font-weight: 600; margin: 8px 0 4px; color: var(--burnish-text, #2D1F1F);
@@ -150,6 +155,7 @@ export class BurnishCard extends LitElement {
             font-size: var(--burnish-font-size-sm, 12px); color: var(--burnish-link, #7C3030);
             opacity: 0.6; transition: opacity var(--burnish-transition-fast);
             cursor: pointer;
+            margin-top: auto;
         }
         .card-action:hover { background: rgba(139, 58, 58, 0.04); }
         .card:hover .card-action { opacity: 1; }


### PR DESCRIPTION
## Summary
Fixes #321, #322, #305, #318, #327, #328, #330, #332, #306, #307, #323

11 visual polish fixes from exploratory testing.

## Changes
- `index.html`: SVG favicon, textarea replaces input, backdrop div
- `style.css`: Markdown styles, single-card width, mobile header, backdrop, textarea
- `app.js`: Tooltip text, sidebar backdrop toggle
- `llm-insight-ui.js`: Auto-resize textarea, mode toggle with icons + hideable labels
- `view-renderers.js`: Markdown file rendering
- `card.ts`: Flex column layout, line-clamp, action pinning

## Verification

**Desktop light — card grid with consistent heights, explore links bottom-aligned (#322, #318):**
![verify-340-desktop-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-340-desktop-light-v2-20260410130308.png)

**Desktop dark:**
![verify-340-desktop-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-340-desktop-dark-v2-20260410130308.png)

**Mobile (375px) — compact header, no toggle text (#306/#307):**
![verify-340-mobile-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-340-mobile-light-v2-20260410130308.png)

**Mobile sidebar with backdrop scrim (#323):**
![verify-340-mobile-sidebar](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-340-mobile-sidebar-v2-20260410130308.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass
- [x] Visual verification confirms fixes in both themes