### PR TITLE
fix(components): layout fixes for dashboard, section collapse, and stat-bar

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -49,7 +49,7 @@ import {
 import {
     renderDeterministicToolListing, generateToolListingHtml,
     renderDeterministicNode, executeToolDirect,
-    getEmptyState, setSessionHelpers,
+    getEmptyState, getDashboardEmptyState, setSessionHelpers,
 } from './deterministic-ui.js';
 
 // ── LLM Insight UI ──
@@ -673,7 +673,7 @@ function renderMainContent() {
     const session = getActiveSession();
 
     if (!session || session.nodes.length === 0) {
-        container.innerHTML = getEmptyState();
+        container.innerHTML = getEmptyState() + getDashboardEmptyState();
         loadDynamicSuggestions(container);
         return;
     }

--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -283,3 +283,17 @@ export function getEmptyState() {
         </div>
     `;
 }
+
+export function getDashboardEmptyState() {
+    return `
+        <div class="burnish-dashboard-empty-state">
+            <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+                <rect x="4" y="8" width="18" height="14" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                <rect x="26" y="8" width="18" height="14" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                <rect x="4" y="26" width="40" height="14" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+            </svg>
+            <h2>Dashboard Mode</h2>
+            <p>Execute tools to populate the dashboard with live data. Each tool result will appear as a tile you can monitor at a glance.</p>
+        </div>
+    `;
+}

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1007,6 +1007,29 @@ body {
     margin-top: 0;
 }
 [data-dashboard="true"] .burnish-empty-state { display: none; }
+.burnish-dashboard-empty-state { display: none; }
+[data-dashboard="true"] .burnish-dashboard-empty-state {
+    display: block;
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--burnish-text-secondary, #6B5A5A);
+    max-width: 480px;
+    margin: 0 auto;
+}
+.burnish-dashboard-empty-state svg {
+    color: var(--burnish-text-muted, #A89999);
+    margin-bottom: 16px;
+}
+.burnish-dashboard-empty-state h2 {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--burnish-text, #2D1F1F);
+    margin-bottom: 8px;
+}
+.burnish-dashboard-empty-state p {
+    font-size: 14px;
+    line-height: 1.5;
+}
 #btn-dashboard-toggle.active {
     color: white;
     background: rgba(255,255,255,0.15);

--- a/packages/components/src/section.ts
+++ b/packages/components/src/section.ts
@@ -56,12 +56,15 @@ export class BurnishSection extends LitElement {
         this.collapsed = false;
     }
 
-    private _toggle() { this.collapsed = !this.collapsed; }
+    private _toggle(e: Event) {
+        e.stopPropagation();
+        this.collapsed = !this.collapsed;
+    }
 
     render() {
         const countText = this.count != null ? `(${this.count})` : '';
         return html`
-            <div class="header" @click=${this._toggle}>
+            <div class="header" @click=${(e: Event) => this._toggle(e)}>
                 <svg class="chevron" viewBox="0 0 16 16" fill="none">
                     <path d="M5 3l5 5-5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>

--- a/packages/components/src/stat-bar.ts
+++ b/packages/components/src/stat-bar.ts
@@ -9,8 +9,8 @@ export class BurnishStatBar extends LitElement {
     };
 
     static styles = css`
-        :host { display: inline-flex; min-width: 0; }
-        .stat-bar { display: flex; flex-direction: row; align-items: center; gap: var(--burnish-space-md, 12px); flex-wrap: nowrap; }
+        :host { display: inline-flex; min-width: 0; max-width: 100%; }
+        .stat-bar { display: flex; flex-direction: row; align-items: center; gap: var(--burnish-space-md, 12px); flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: thin; }
         .stat-chip {
             display: flex; align-items: center; gap: var(--burnish-space-sm, 8px);
             background: var(--burnish-surface, #fff);


### PR DESCRIPTION
## Summary
Fixes #320, #316, #315

- **#320**: Dashboard mode now shows an instructional empty state instead of a blank page
- **#316**: Section collapse toggle now responds to clicks (event propagation fix)
- **#315**: Stat-bar chips scroll horizontally at 768px instead of being clipped

## Root Cause
- #320: Dashboard mode CSS hid all content with no fallback empty state
- #316: Click events on section headers were consumed by parent handlers before reaching _toggle()
- #315: Stat-bar container had no overflow handling, causing chips to clip

## Changes
- app.js/deterministic-ui.js/style.css: Added .burnish-dashboard-empty-state visible only in [data-dashboard="true"] mode
- section.ts: Fixed this binding in click handler; added e.stopPropagation() in _toggle()
- stat-bar.ts: Added overflow-x: auto, -webkit-overflow-scrolling: touch, scrollbar-width: thin, max-width: 100%

## Verification

**Desktop — Light mode (stat-bar + sections visible):**
![verify-341-desktop-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-341-desktop-light-20260410082218.png)

**Desktop — Dark mode:**
![verify-341-desktop-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-341-desktop-dark-20260410082218.png)

**#320 — Dashboard empty state (light):**
![verify-341-dashboard-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-341-dashboard-light-20260410082218.png)

**#320 — Dashboard empty state (dark):**
![verify-341-dashboard-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-341-dashboard-dark-20260410082218.png)

**#316 — Section collapsed (Read Operations collapsed, Write/Edit visible):**
![verify-341-section-collapsed](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-341-section-collapsed-20260410082218.png)

**#315 — Stat-bar at 768px tablet viewport (no chip clipping):**
![verify-341-statbar-tablet](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-341-statbar-tablet-20260410082218.png)

## Test Plan
- [x] pnpm build passes
- [ ] CI tests pass
- [x] Visual verification: dashboard empty state visible in both themes
- [x] Visual verification: section collapse responds to clicks, chevron rotates
- [x] Visual verification: stat-bar chips visible without clipping at 768px