### PR TITLE
fix(components): support array fields in drill-down forms

### DIFF
--- a/packages/app/src/drill-down.ts
+++ b/packages/app/src/drill-down.ts
@@ -70,13 +70,21 @@ export function generateFallbackForm(
     const props = schema.properties || {};
     const required = new Set(schema.required || []);
     const fields = Object.entries(props).map(([key, prop]) => {
+        const isArray = prop.type === 'array';
         const field: Record<string, any> = {
             key,
             label: prop.title || key.replace(/_/g, ' '),
             type: prop.type === 'number' || prop.type === 'integer' ? 'number' : prop.enum ? 'select' : 'text',
             required: required.has(key),
         };
-        if (prop.description) field.placeholder = prop.description;
+        if (isArray) {
+            field.placeholder = prop.description
+                ? `${prop.description} (comma-separated)`
+                : '(comma-separated)';
+            field.array = true;
+        } else if (prop.description) {
+            field.placeholder = prop.description;
+        }
         if (prop.default !== undefined) field.value = String(prop.default);
         if (prop.enum) field.options = prop.enum.map(String);
         return field;

--- a/packages/components/src/form.ts
+++ b/packages/components/src/form.ts
@@ -9,6 +9,7 @@ interface FormField {
     value?: string;
     options?: Array<{ value: string; label: string }>;
     lookup?: { prompt: string; placeholder?: string };
+    array?: boolean;
 }
 
 interface LookupResult {
@@ -222,13 +223,24 @@ export class BurnishForm extends LitElement {
     private _handleSubmit(e: Event) {
         e.preventDefault();
         const fields = this._getFields();
-        const values: Record<string, string> = {};
+        const values: Record<string, string | string[]> = {};
         for (const field of fields) {
             const input = this.shadowRoot?.querySelector(`[data-key="${field.key}"]`) as HTMLInputElement | HTMLTextAreaElement | null;
-            if (input) values[field.key] = input.value;
+            if (input) {
+                if (field.array) {
+                    values[field.key] = input.value
+                        .split(',')
+                        .map(s => s.trim())
+                        .filter(s => s.length > 0);
+                } else {
+                    values[field.key] = input.value;
+                }
+            }
         }
         for (const field of fields) {
-            if (field.required && !values[field.key]?.trim()) {
+            const v = values[field.key];
+            const isEmpty = Array.isArray(v) ? v.length === 0 : !v?.trim();
+            if (field.required && isEmpty) {
                 this._status = 'error';
                 this._statusMsg = `${field.label} is required`;
                 return;


### PR DESCRIPTION
## Summary
Fixes #334

The search_files tool (and others with array parameters) failed silently because the form system had no array field type.

## Root Cause
`generateFallbackForm()` in `drill-down.ts` skipped properties with `type: 'array'`, producing forms missing required fields.

## Changes
- `drill-down.ts`: Array-typed schema properties now render as text inputs with `array: true` flag and "(comma-separated)" placeholder
- `form.ts`: Added `array?: boolean` to `FormField` interface; `_handleSubmit()` splits comma-separated values into string arrays

## Verification

**Tool grid with MCP server connected:**
![verify-338-tools](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-338-tools-light-20260410082607.png)

**Form with array field showing "(comma-separated)" placeholder — Light:**
![verify-338-form-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-338-form-light-20260410082607.png)

**Form — Dark:**
![verify-338-form-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-338-form-dark-20260410082607.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass
- [ ] Manual: drill into search_files, enter comma-separated values, verify array is sent