### PR TITLE
fix(deploy): correct dockerfile path in fly.toml

### DIFF
--- a/deploy/demo/fly.toml
+++ b/deploy/demo/fly.toml
@@ -2,7 +2,7 @@ app = "burnish-demo"
 primary_region = "iad"
 
 [build]
-  dockerfile = "deploy/demo/Dockerfile"
+  dockerfile = "Dockerfile"
 
 [env]
   LLM_BACKEND = "none"


### PR DESCRIPTION
## Summary
Fixes deploy failure — flyctl resolves dockerfile relative to config file directory, doubling the path.

## Fix
Changed `dockerfile = "deploy/demo/Dockerfile"` to `dockerfile = "Dockerfile"` in fly.toml.

## Test Plan
- [ ] Merge and re-trigger deploy workflow