### PR TITLE
fix(deploy): add git to Docker builder for prepare script

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim AS builder
 
 # Install pnpm + build tools for native modules (better-sqlite3)
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate \
-    && apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
+    && apt-get update && apt-get install -y python3 build-essential git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
Docker build fails because pnpm's prepare script runs `git config core.hooksPath .githooks` but git isn't installed in the builder stage.

## Fix
Added `git` to the apt-get install in the builder stage.

## Test Plan
- [ ] Merge and re-trigger deploy workflow