### PR TITLE
fix(deploy): skip prepare script in Docker build

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim AS builder
 
 # Install pnpm + build tools for native modules (better-sqlite3)
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate \
-    && apt-get update && apt-get install -y python3 build-essential git && rm -rf /var/lib/apt/lists/*
+    && apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
@@ -16,7 +16,7 @@ COPY packages/app/package.json packages/app/
 COPY packages/example-server/package.json packages/example-server/
 COPY apps/demo/package.json apps/demo/
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
 
 # Copy source and build
 COPY packages/ packages/


### PR DESCRIPTION
## Summary
Docker build fails because the pnpm prepare script runs `git config core.hooksPath .githooks` which requires a git repo (not present in Docker).

## Fix
- Removed `git` from builder apt-get (not needed)
- Added `--ignore-scripts` to `pnpm install` to skip the prepare hook
- Added `pnpm rebuild` to compile native modules (better-sqlite3)

## Test Plan
- [ ] Merge and re-trigger deploy workflow