### PR TITLE
fix(deploy): use pnpm config to ignore scripts in Docker build

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -16,7 +16,10 @@ COPY packages/app/package.json packages/app/
 COPY packages/example-server/package.json packages/example-server/
 COPY apps/demo/package.json apps/demo/
 
-RUN pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
+RUN pnpm config set ignore-scripts true \
+    && pnpm install --frozen-lockfile \
+    && pnpm rebuild \
+    && pnpm config delete ignore-scripts
 
 # Copy source and build
 COPY packages/ packages/


### PR DESCRIPTION
## Summary
pnpm rebuild also triggers the prepare script, so `--ignore-scripts` on install alone isn't sufficient. Uses `pnpm config set ignore-scripts true` to suppress all lifecycle scripts during the Docker build.

## Test Plan
- [ ] Merge and re-trigger deploy workflow