### PR TITLE
fix(deploy): add git to Docker builder stage

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim AS builder
 
 # Install pnpm + build tools for native modules (better-sqlite3)
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate \
-    && apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
+    && apt-get update && apt-get install -y python3 build-essential git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
Fixes #355

## Root Cause
The root `package.json` has a `prepare` script that runs `git config core.hooksPath .githooks`. The Dockerfile runs `pnpm install --ignore-scripts && pnpm rebuild`, but `pnpm rebuild` triggers lifecycle scripts including `prepare`, which fails with `sh: 1: git: not found` because `git` is not installed in the builder stage.

## Fix
Added `git` to the `apt-get install` line in the builder stage of `deploy/demo/Dockerfile`. This ensures the `prepare` lifecycle script can execute successfully during `pnpm rebuild`.

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Docker build succeeds with `git` available in builder stage