### PR TITLE
fix(deploy): init git repo in Docker builder for prepare script

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -16,7 +16,7 @@ COPY packages/app/package.json packages/app/
 COPY packages/example-server/package.json packages/example-server/
 COPY apps/demo/package.json apps/demo/
 
-RUN pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
+RUN git init && pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
 
 # Copy source and build
 COPY packages/ packages/


### PR DESCRIPTION
## Summary
Fixes #355

## Root Cause
PR #356 added `git` to the Docker builder stage, fixing the initial "git: not found" error. However, the `prepare` script in `package.json` runs `git config core.hooksPath .githooks`, which fails with `fatal: not in a git directory` because the Docker build context at `/build` is not a git repository.

## Fix
Added `git init` before `pnpm install` in the builder stage. This creates a minimal git repo so the `prepare` script's `git config` command succeeds. The hooks path configuration is harmless inside the Docker build — no git hooks actually run during the image build.

## Test Plan
- [ ] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Docker image builds successfully on Cloud Run deploy