### PR TITLE
fix(deploy): exclude CLI package from Docker build

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -21,7 +21,7 @@ RUN git init && pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
 # Copy source and build
 COPY packages/ packages/
 COPY apps/demo/ apps/demo/
-RUN pnpm -r build
+RUN pnpm -r build --filter '!burnish'
 
 # Pre-install MCP server packages so npx doesn't download at runtime
 RUN npm install -g @modelcontextprotocol/server-filesystem@latest @modelcontextprotocol/server-sqlite@latest


### PR DESCRIPTION
## Summary
Fixes #355

## Root Cause
The Docker build runs `pnpm -r build`, which attempts to build all workspace packages including `packages/cli` (package name: `burnish`). The CLI package requires `tsc` and runs `scripts/bundle-assets.js`, but its `package.json` is never copied into the Docker builder stage — so it has no `node_modules` and `tsc` is not found. The demo deployment does not need the CLI package at all.

## Fix
Change the build command in `deploy/demo/Dockerfile` from `pnpm -r build` to `pnpm -r build --filter '!burnish'`, which excludes the CLI package from the recursive build. All packages needed by the demo (components, renderer, server, app, example-server, demo) continue to build successfully.

## Test Plan
- [x] `pnpm build` passes locally
- [ ] CI tests pass (automated on PR)
- [ ] Docker build succeeds in Cloud Run deployment