### PR TITLE
fix(deploy): correct pnpm filter flag position in Dockerfile

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -21,7 +21,7 @@ RUN git init && pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild
 # Copy source and build
 COPY packages/ packages/
 COPY apps/demo/ apps/demo/
-RUN pnpm -r build --filter '!burnish'
+RUN pnpm --filter '!burnish' -r build
 
 # Pre-install MCP server packages so npx doesn't download at runtime
 RUN npm install -g @modelcontextprotocol/server-filesystem@latest @modelcontextprotocol/server-sqlite@latest


### PR DESCRIPTION
## Summary
Fixes #355

## Root Cause
The `--filter '!burnish'` flag was placed after `build` in `pnpm -r build --filter '!burnish'`, causing pnpm to pass `--filter` as an argument to the underlying `tsc` build script rather than interpreting it as a pnpm workspace filter. This resulted in: `error TS5023: Unknown compiler option '--filter'`.

## Fix
Moved `--filter '!burnish'` before the `-r build` command so pnpm processes it as a workspace filter:

```dockerfile
# Before
RUN pnpm -r build --filter '!burnish'

# After
RUN pnpm --filter '!burnish' -r build
```

## Test Plan
- [x] `pnpm build` passes locally
- [ ] CI tests pass (automated on PR)
- [ ] Docker build succeeds on deploy