### PR TITLE
fix(deploy): use mcp-server-sqlite-npx for Node-compatible SQLite MCP server

### DIFF
--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -24,7 +24,7 @@ COPY apps/demo/ apps/demo/
 RUN pnpm --filter '!burnish' -r build
 
 # Pre-install MCP server packages so npx doesn't download at runtime
-RUN npm install -g @modelcontextprotocol/server-filesystem@latest @modelcontextprotocol/server-sqlite@latest
+RUN npm install -g @modelcontextprotocol/server-filesystem@latest mcp-server-sqlite-npx@latest
 
 # Stage 2: Runtime
 FROM node:20-slim AS runner

--- a/deploy/demo/mcp-servers.demo.json
+++ b/deploy/demo/mcp-servers.demo.json
@@ -6,7 +6,7 @@
     },
     "demo-database": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sqlite", "--db-path", "/data/demo.db"]
+      "args": ["-y", "mcp-server-sqlite-npx", "--db-path", "/data/demo.db"]
     },
     "showcase": {
       "command": "node",


### PR DESCRIPTION
## Summary
Fixes #355

## Root Cause
The Docker build for the demo deployment installs `@modelcontextprotocol/server-sqlite` via npm, but that package does not exist on the npm registry — the official MCP SQLite server is a Python package only. This causes a 404 error during `npm install -g` in the Dockerfile build stage.

## Fix
Replace `@modelcontextprotocol/server-sqlite` with `mcp-server-sqlite-npx`, a community Node.js-compatible alternative that provides the same SQLite MCP server functionality and uses the same `--db-path` argument format.

Changes in two files:
- `deploy/demo/Dockerfile` — updated the `npm install -g` line to install `mcp-server-sqlite-npx@latest`
- `deploy/demo/mcp-servers.demo.json` — updated the `demo-database` server args to use `mcp-server-sqlite-npx`

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Docker build succeeds with the new package (verified in deploy pipeline)