### PR TITLE
feat(example-server): render sales data as chart + stat-bar

### DIFF
--- a/packages/example-server/src/index.ts
+++ b/packages/example-server/src/index.ts
@@ -151,34 +151,28 @@ server.tool(
   "Returns monthly sales data with categories, amounts, and trends for chart visualization",
   {},
   async () => {
-    const salesData = {
-      period: "2025 Q1-Q4",
-      currency: "USD",
-      totalRevenue: "$1,466,000",
-      topCategory: "Software",
-      growthRate: "97.6%",
-      averageMonthly: "$122,167",
-      janTotal: "$85,000",
-      febTotal: "$92,000",
-      marTotal: "$99,000",
-      q1Revenue: "$276,000",
-      aprTotal: "$105,000",
-      mayTotal: "$111,000",
-      junTotal: "$121,000",
-      q2Revenue: "$337,000",
-      julTotal: "$128,000",
-      augTotal: "$131,000",
-      sepTotal: "$128,000",
-      q3Revenue: "$387,000",
-      octTotal: "$150,000",
-      novTotal: "$148,000",
-      decTotal: "$168,000",
-      q4Revenue: "$466,000",
+    const summary = [
+      { label: "Total Revenue", value: "$1,466,000" },
+      { label: "Growth Rate", value: "97.6%" },
+      { label: "Top Category", value: "Software" },
+      { label: "Avg Monthly", value: "$122,167" },
+    ];
+
+    const chart = {
+      title: "Monthly Revenue — 2025",
+      labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+      datasets: [
+        {
+          label: "Revenue ($k)",
+          data: [85, 92, 99, 105, 111, 121, 128, 131, 128, 150, 148, 168],
+        },
+      ],
     };
 
     return {
       content: [
-        { type: "text" as const, text: JSON.stringify(salesData, null, 2) },
+        { type: "text" as const, text: JSON.stringify(summary, null, 2) },
+        { type: "text" as const, text: JSON.stringify(chart, null, 2) },
       ],
     };
   }


### PR DESCRIPTION
## Summary
Closes #355

The `get-sales-data` tool in the example server returned flat key-value pairs, which the burnish renderer displayed as a plain key-value table. This changes the response to use chart-friendly data structures that the renderer auto-maps to richer components.

## Fix / Changes
Replaced the single flat object response with two content items:

1. **Stat-bar summary** — an array of `{label, value}` objects (Total Revenue, Growth Rate, Top Category, Avg Monthly) that renders as a `burnish-stat-bar`
2. **Line chart** — an object with `title`, `labels`, and `datasets` fields (monthly revenue for 2025) that renders as a `burnish-chart`

The underlying data (revenue figures, growth rate, etc.) is unchanged — only the shape of the response is different so the renderer picks the right components.

## Verification
This is a visual change to the demo at burnish-demo.fly.dev. After deployment, the sales data tool will render a stat-bar with summary metrics above a line chart showing monthly revenue, instead of a flat key-value list.

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Visual verification on deployed demo after merge