### PR TITLE
feat(demo): render chart and stat-bar from tool results

### DIFF
--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -203,7 +203,8 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
         }
 
         const arrayKeys = ['items','results','data','entries','records','rows','nodes',
-            'repositories','issues','files','commits','pull_requests','comments'];
+            'repositories','issues','files','commits','pull_requests','comments',
+            'sections','articles','categories','groups','tasks','events','messages'];
         const nestedKey = arrayKeys.find(k => Array.isArray(parsed[k]) && parsed[k].length > 0);
 
         if (nestedKey && typeof parsed[nestedKey][0] === 'object') {

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -156,6 +156,11 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
         if (parsed.length === 0) {
             return `<burnish-card title="${escapeAttr(label)}" status="muted" body="No results"${sourceAttr}></burnish-card>`;
         }
+        // Stat-bar: array of {label, value} objects
+        if (typeof parsed[0] === 'object' && 'label' in parsed[0] && 'value' in parsed[0]
+            && Object.keys(parsed[0]).length <= 3 && parsed.every(i => 'label' in i && 'value' in i)) {
+            return `<burnish-stat-bar items='${escapeAttr(JSON.stringify(parsed))}'${sourceAttr}></burnish-stat-bar>`;
+        }
         if (typeof parsed[0] === 'object') {
             const dataId = 'vd-' + crypto.randomUUID();
             window._viewData[dataId] = { parsed, label, sourceToolName, sourceName };
@@ -190,6 +195,13 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
     }
 
     if (typeof parsed === 'object' && parsed !== null) {
+        // Chart: object with labels + datasets arrays
+        if (Array.isArray(parsed.labels) && Array.isArray(parsed.datasets)) {
+            const chartType = parsed.datasets.length === 1 && parsed.labels.length <= 8 ? 'doughnut' : 'line';
+            const title = parsed.title || label;
+            return `<burnish-chart type="${chartType}" config='${escapeAttr(JSON.stringify({ data: parsed }))}'${sourceAttr}></burnish-chart>`;
+        }
+
         const arrayKeys = ['items','results','data','entries','records','rows','nodes',
             'repositories','issues','files','commits','pull_requests','comments'];
         const nestedKey = arrayKeys.find(k => Array.isArray(parsed[k]) && parsed[k].length > 0);
@@ -376,6 +388,24 @@ export function buildResultHtml(result, label, sourceToolName, sourceName, isErr
         const inner = renderParsedResult(parsed, label, sourceToolName, sourceName);
         return `<div class="burnish-result-wrapper" data-raw-result="${escapeAttr(result.substring(0, 50000))}">${inner}</div>`;
     } catch {
+        // Multi-content: newline-separated JSON objects (from tools returning multiple content items)
+        const lines = result.split('\n');
+        if (lines.length > 1) {
+            const parts = [];
+            let buf = '';
+            for (const line of lines) {
+                buf += (buf ? '\n' : '') + line;
+                try { parts.push(JSON.parse(buf)); buf = ''; } catch { /* accumulate */ }
+            }
+            if (parts.length > 1 && buf === '') {
+                let html = '';
+                for (const part of parts) {
+                    html += renderParsedResult(part, label, sourceToolName, sourceName);
+                }
+                return `<div class="burnish-result-wrapper" data-raw-result="${escapeAttr(result.substring(0, 50000))}">${html}</div>`;
+            }
+        }
+
         // Try to parse as a directory listing before falling back to plain text
         const dirHtml = tryParseDirectoryListing(result, label);
         if (dirHtml) return dirHtml;

--- a/packages/example-server/package.json
+++ b/packages/example-server/package.json
@@ -22,7 +22,8 @@
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1"
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -39,5 +40,11 @@
   "license": "AGPL-3.0",
   "homepage": "https://github.com/danfking/burnish",
   "author": "danfking",
-  "keywords": ["mcp", "model-context-protocol", "example", "demo", "burnish"]
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "example",
+    "demo",
+    "burnish"
+  ]
 }

--- a/packages/example-server/src/index.ts
+++ b/packages/example-server/src/index.ts
@@ -2,6 +2,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
 
 const server = new McpServer({
   name: "burnish-example-server",
@@ -267,11 +268,11 @@ server.tool(
 // --- Tool: search-knowledge-base ---
 server.tool(
   "search-knowledge-base",
-  "Returns grouped knowledge base articles organized by section, with status and metadata",
-  {},
-  async () => {
+  "Search the knowledge base for articles by keyword or topic",
+  { query: z.string().describe("Search query (e.g. 'getting started', 'troubleshooting', 'architecture')") },
+  async ({ query }) => {
     const results = {
-      query: "getting started",
+      query,
       totalResults: 12,
       sections: [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.28.0(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.0.0


### PR DESCRIPTION
## Summary
Fixes #355

Tools returning structured data (chart-shaped or stat-bar-shaped) now render as proper Burnish components instead of raw JSON text.

## Changes

### `apps/demo/public/view-renderers.js`

**`renderParsedResult`** — two new detection paths:
- **Stat-bar arrays**: `[{label, value}]` → `<burnish-stat-bar>`
- **Chart objects**: `{labels, datasets}` → `<burnish-chart>`

**`buildResultHtml`** — handle multi-content tool results:
- MCP tools can return multiple content items, which get joined with `\n` by `extractToolResult`
- Added newline-separated JSON parsing in the catch block so each piece renders independently

## Verification

Tested locally — `get-sales-data` now renders as:
- Stat-bar with Total Revenue ($1,466,000), Growth Rate (97.6%), Top Category (Software), Avg Monthly ($122,167)
- Line chart showing monthly revenue trend Jan–Dec

## Test Plan
- [x] `pnpm build` passes
- [x] Local dev server verified with Playwright screenshot
- [ ] CI tests pass