### PR TITLE
feat(demo): demonstrate all burnish components in showcase

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -875,7 +875,13 @@ body {
     gap: var(--burnish-space-sm, 8px);
     align-items: flex-start;
 }
-.burnish-result-wrapper > :not(burnish-stat-bar) {
+.burnish-result-wrapper > :not(burnish-stat-bar):not(.burnish-metrics-grid) {
+    width: 100%;
+}
+.burnish-metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--burnish-space-md, 12px);
     width: 100%;
 }
 @media (max-width: 768px) {

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -175,7 +175,17 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
                 const status = section.status || 'info';
                 html += `<burnish-section label="${escapeAttr(String(title))}" count="${count}" status="${status}">`;
                 if (nestedArrayKey) {
-                    html += renderParsedResult(section[nestedArrayKey], title, sourceToolName, sourceName);
+                    // Render nested items as compact cards directly (no stat-bar/view-switcher)
+                    for (const item of section[nestedArrayKey]) {
+                        if (typeof item === 'object' && item !== null) {
+                            const titleFields = ['name', 'title', 'path', 'filename', 'full_name', 'login', 'label'];
+                            const itemTitle = titleFields.reduce((acc, k) => acc || (item[k] ? String(item[k]) : ''), '') || title;
+                            const meta = Object.entries(item)
+                                .filter(([, v]) => (typeof v !== 'object' || v === null) && typeof v !== 'boolean')
+                                .map(([k, v]) => ({ label: k.replace(/_/g, ' '), value: String(v ?? '') }));
+                            html += `<burnish-card title="${escapeAttr(itemTitle)}" status="${escapeAttr(item.status || 'success')}" meta='${escapeAttr(JSON.stringify(meta))}'${sourceAttr}></burnish-card>`;
+                        }
+                    }
                 }
                 html += `</burnish-section>`;
             }

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -439,8 +439,13 @@ export function buildResultHtml(result, label, sourceToolName, sourceName, isErr
             }
             if (parts.length > 1 && buf === '') {
                 let html = '';
+                // Check if all parts are metric-shaped — wrap in grid
+                const allMetrics = parts.every(p => typeof p === 'object' && !Array.isArray(p) && 'label' in p && 'value' in p && ('trend' in p || 'unit' in p));
                 for (const part of parts) {
                     html += renderParsedResult(part, label, sourceToolName, sourceName);
+                }
+                if (allMetrics) {
+                    html = `<div class="burnish-metrics-grid">${html}</div>`;
                 }
                 return `<div class="burnish-result-wrapper" data-raw-result="${escapeAttr(result.substring(0, 50000))}">${html}</div>`;
             }

--- a/apps/demo/public/view-renderers.js
+++ b/apps/demo/public/view-renderers.js
@@ -161,6 +161,26 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
             && Object.keys(parsed[0]).length <= 3 && parsed.every(i => 'label' in i && 'value' in i)) {
             return `<burnish-stat-bar items='${escapeAttr(JSON.stringify(parsed))}'${sourceAttr}></burnish-stat-bar>`;
         }
+        // Section-shaped arrays: items with {title/label, count?, articles/items/children (nested array)}
+        if (typeof parsed[0] === 'object' && parsed.every(item => {
+            const hasTitle = 'title' in item || 'label' in item || 'name' in item;
+            const hasNested = Object.values(item).some(v => Array.isArray(v) && v.length > 0);
+            return hasTitle && hasNested;
+        })) {
+            let html = '';
+            for (const section of parsed) {
+                const title = section.title || section.label || section.name || 'Section';
+                const nestedArrayKey = Object.keys(section).find(k => Array.isArray(section[k]) && section[k].length > 0);
+                const count = section.count || (nestedArrayKey ? section[nestedArrayKey].length : 0);
+                const status = section.status || 'info';
+                html += `<burnish-section label="${escapeAttr(String(title))}" count="${count}" status="${status}">`;
+                if (nestedArrayKey) {
+                    html += renderParsedResult(section[nestedArrayKey], title, sourceToolName, sourceName);
+                }
+                html += `</burnish-section>`;
+            }
+            return html;
+        }
         if (typeof parsed[0] === 'object') {
             const dataId = 'vd-' + crypto.randomUUID();
             window._viewData[dataId] = { parsed, label, sourceToolName, sourceName };
@@ -200,6 +220,25 @@ export function renderParsedResult(parsed, label, sourceToolName, sourceName) {
             const chartType = parsed.datasets.length === 1 && parsed.labels.length <= 8 ? 'doughnut' : 'line';
             const title = parsed.title || label;
             return `<burnish-chart type="${chartType}" config='${escapeAttr(JSON.stringify({ data: parsed }))}'${sourceAttr}></burnish-chart>`;
+        }
+
+        // Pipeline: object with _ui_hint === "pipeline" and steps array
+        if (parsed._ui_hint === 'pipeline' && Array.isArray(parsed.steps)) {
+            return `<burnish-pipeline steps='${escapeAttr(JSON.stringify(parsed.steps))}'${sourceAttr}></burnish-pipeline>`;
+        }
+
+        // Metric: object with label + value + optional trend/unit, ≤5 keys
+        if ('label' in parsed && 'value' in parsed && ('trend' in parsed || 'unit' in parsed)) {
+            const keys = Object.keys(parsed).filter(k => !k.startsWith('_'));
+            if (keys.length <= 5) {
+                const attrs = [
+                    `label="${escapeAttr(String(parsed.label))}"`,
+                    `value="${escapeAttr(String(parsed.value))}"`,
+                    parsed.unit ? `unit="${escapeAttr(String(parsed.unit))}"` : '',
+                    parsed.trend ? `trend="${escapeAttr(String(parsed.trend))}"` : '',
+                ].filter(Boolean).join(' ');
+                return `<burnish-metric ${attrs}${sourceAttr}></burnish-metric>`;
+            }
         }
 
         const arrayKeys = ['items','results','data','entries','records','rows','nodes',

--- a/packages/example-server/src/index.ts
+++ b/packages/example-server/src/index.ts
@@ -186,22 +186,108 @@ server.tool(
   {},
   async () => {
     const pipeline = {
-      name: "Production Release v2.4.1",
-      triggeredBy: "Alice Chen",
-      startedAt: "2026-04-10T09:15:00Z",
-      stages: [
-        { name: "Build", status: "success", duration: "2m 14s", details: "TypeScript compiled, 0 errors" },
-        { name: "Unit Tests", status: "success", duration: "1m 48s", details: "342 tests passed" },
-        { name: "Integration Tests", status: "success", duration: "4m 32s", details: "28 suites, all green" },
-        { name: "Security Scan", status: "running", duration: "1m 05s", details: "Scanning dependencies..." },
-        { name: "Staging Deploy", status: "pending", duration: null, details: "Waiting for security scan" },
-        { name: "Production Deploy", status: "pending", duration: null, details: "Requires manual approval" },
+      _ui_hint: "pipeline",
+      steps: [
+        { server: "ci", tool: "build", status: "success", duration: "2m 14s" },
+        { server: "ci", tool: "unit-tests", status: "success", duration: "1m 48s" },
+        { server: "ci", tool: "integration-tests", status: "success", duration: "4m 32s" },
+        { server: "security", tool: "dependency-scan", status: "running", duration: "1m 05s" },
+        { server: "deploy", tool: "staging", status: "pending" },
+        { server: "deploy", tool: "production", status: "pending" },
       ],
     };
 
     return {
       content: [{ type: "text" as const, text: JSON.stringify(pipeline, null, 2) }],
     };
+  }
+);
+
+// --- Tool: get-server-metrics ---
+server.tool(
+  "get-server-metrics",
+  "Returns live server performance metrics with trend indicators",
+  {},
+  async () => {
+    const metrics = [
+      { label: "Uptime", value: "99.97", unit: "%", trend: "flat" },
+      { label: "Avg Response", value: "42", unit: "ms", trend: "down" },
+      { label: "Active Users", value: "1,847", trend: "up" },
+      { label: "Error Rate", value: "0.03", unit: "%", trend: "down" },
+    ];
+    return {
+      content: metrics.map(m => ({ type: "text" as const, text: JSON.stringify(m) })),
+    };
+  }
+);
+
+// --- Tool: list-api-endpoints ---
+server.tool(
+  "list-api-endpoints",
+  "Returns API endpoint documentation with methods, paths, and descriptions",
+  {},
+  async () => {
+    const endpoints = [
+      { method: "GET", path: "/api/servers", status: "stable", auth: "optional", description: "List connected MCP servers" },
+      { method: "POST", path: "/api/tools/execute", status: "stable", auth: "required", description: "Execute a tool directly" },
+      { method: "GET", path: "/api/health", status: "stable", auth: "none", description: "Health check endpoint" },
+      { method: "POST", path: "/api/chat", status: "stable", auth: "required", description: "Create a new conversation" },
+      { method: "GET", path: "/api/chat/:id/stream", status: "stable", auth: "required", description: "Stream conversation responses via SSE" },
+      { method: "GET", path: "/api/models", status: "stable", auth: "optional", description: "List available LLM models" },
+      { method: "GET", path: "/api/prompts", status: "beta", auth: "optional", description: "List MCP prompt templates" },
+      { method: "POST", path: "/api/prompts/execute", status: "beta", auth: "required", description: "Execute a prompt template" },
+      { method: "GET", path: "/api/resources", status: "beta", auth: "optional", description: "List MCP resources" },
+      { method: "GET", path: "/api/resources/:uri", status: "beta", auth: "required", description: "Read a specific resource" },
+      { method: "POST", path: "/api/tools/batch", status: "experimental", auth: "required", description: "Execute multiple tools in sequence" },
+      { method: "GET", path: "/api/sessions", status: "stable", auth: "required", description: "List active sessions" },
+      { method: "DELETE", path: "/api/sessions/:id", status: "stable", auth: "required", description: "Delete a session" },
+      { method: "GET", path: "/api/schema/:tool", status: "stable", auth: "none", description: "Get JSON schema for a tool" },
+      { method: "POST", path: "/api/webhooks", status: "experimental", auth: "required", description: "Register a webhook for tool events" },
+    ];
+    return { content: [{ type: "text" as const, text: JSON.stringify(endpoints) }] };
+  }
+);
+
+// --- Tool: create-bug-report ---
+server.tool(
+  "create-bug-report",
+  "Submit a bug report with details for tracking",
+  {
+    title: z.string().describe("Bug title"),
+    severity: z.enum(["low", "medium", "high", "critical"]).describe("Severity level"),
+    description: z.string().describe("Detailed description of the bug"),
+    steps_to_reproduce: z.string().optional().describe("Steps to reproduce the issue"),
+  },
+  async ({ title, severity, description, steps_to_reproduce }) => {
+    const report = {
+      id: "BUG-" + Math.floor(Math.random() * 9000 + 1000),
+      title,
+      severity,
+      description,
+      steps_to_reproduce: steps_to_reproduce || "Not provided",
+      status: "Open",
+      assignee: "Unassigned",
+      createdAt: new Date().toISOString(),
+    };
+    return { content: [{ type: "text" as const, text: JSON.stringify(report) }] };
+  }
+);
+
+// --- Tool: get-team-performance ---
+server.tool(
+  "get-team-performance",
+  "Returns quarterly team performance data for bar chart visualization",
+  {},
+  async () => {
+    const performance = {
+      title: "Team Performance — Q1 2026",
+      labels: ["Frontend", "Backend", "DevOps", "QA", "Design"],
+      datasets: [
+        { label: "Tasks Completed", data: [48, 62, 35, 41, 28] },
+        { label: "Story Points", data: [142, 198, 95, 120, 78] },
+      ],
+    };
+    return { content: [{ type: "text" as const, text: JSON.stringify(performance) }] };
   }
 );
 


### PR DESCRIPTION
## Summary
Fixes #365

The showcase MCP server only demonstrated 4 of 10 components (40%). This PR brings coverage to 8/8 demonstrable components (100%).

## Changes

### Example Server (`packages/example-server/src/index.ts`)
- **Restructured** `get-deployment-pipeline` — now returns `_ui_hint: "pipeline"` with `steps` array
- **New** `get-server-metrics` — 4 KPIs with trend indicators (up/down/flat)
- **New** `list-api-endpoints` — 15-row dataset for table rendering
- **New** `create-bug-report` — write tool with Zod schema for form demo
- **New** `get-team-performance` — multi-dataset chart for team comparison

### Renderer (`apps/demo/public/view-renderers.js`)
- **Pipeline detection** — objects with `_ui_hint === "pipeline"` render as `<burnish-pipeline>`
- **Metric detection** — small objects with `{label, value, trend?, unit?}` render as `<burnish-metric>`
- **Metrics grid** — multiple metrics wrap in a responsive CSS grid (auto-fit, min 200px)
- **Section detection** — arrays of objects with title + nested array render as `<burnish-section>` with compact card children

## Verification

### Pipeline (`get-deployment-pipeline`)
![verify-365-pipeline](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-365-pipeline-20260412091939.png)

### Metrics (`get-server-metrics`)
![verify-365-metrics](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-365-metrics-grid-20260412092412.png)

### Table (`list-api-endpoints`)
![verify-365-table](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-365-table-20260412091942.png)

### Chart (`get-team-performance`)
![verify-365-chart](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-365-chart-20260412091957.png)

### Form (`create-bug-report`)
![verify-365-form](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-365-form-20260412091950.png)

### Sections (`search-knowledge-base`)
![verify-365-sections](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-365-sections-v2-20260412093500.png)

## Test Plan
- [x] `pnpm build` passes
- [x] Pipeline renders with 6 steps (success/running/pending)
- [x] Metrics render in 4-column grid with trend arrows
- [x] Table renders with 15 rows, pagination, sorting
- [x] Chart renders with multi-dataset comparison
- [x] Form renders with 4 input fields + submit
- [x] Sections render with nested article cards in grid