### PR TITLE
fix(ux): auto-create session on first visit

### DIFF
--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -137,14 +137,16 @@
         <main id="content-area" class="burnish-content">
             <div id="dashboard-container" class="burnish-dashboard">
                 <div class="burnish-empty-state">
-                    <div class="burnish-empty-icon">
-                        <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
-                            <circle cx="24" cy="24" r="20" stroke="#d1d5db" stroke-width="2" fill="none"/>
-                            <path d="M16 24h16M24 16v16" stroke="#d1d5db" stroke-width="2" stroke-linecap="round"/>
-                        </svg>
+                    <h2>Burnish</h2>
+                    <p>Explore your data visually through connected services</p>
+                    <div class="burnish-server-buttons" id="server-buttons">
+                        <div class="burnish-suggestion-skeleton-pill"></div>
+                        <div class="burnish-suggestion-skeleton-pill"></div>
                     </div>
-                    <h2>Welcome to Burnish</h2>
-                    <p>Explore your data visually through connected services.</p>
+                    <div class="burnish-tool-shortcuts" id="tool-shortcuts"></div>
+                    <div class="burnish-starter-prompts" id="starter-prompts"></div>
+                    <div class="burnish-recent-prompts" id="recent-prompts"></div>
+                    <div class="burnish-empty-hint" id="empty-hint"></div>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
## Summary
Fixes #363

On first visit with no stored sessions, users saw a static "Welcome to Burnish" screen with a non-interactive "+" circle icon. Now they land directly on the server button layout with skeleton loading pills, matching the dynamic empty state.

## Root Cause
The static HTML in `index.html` inside `dashboard-container` showed a decorative "+" SVG and "Welcome to Burnish" heading. While the JavaScript already auto-creates a session on startup (and replaces this with the dynamic empty state including server buttons), the initial HTML did not match, causing a visible flash of the wrong content.

## Fix
Replaced the static HTML in `index.html` to match the dynamic empty state from `getEmptyState()` in `deterministic-ui.js`. The initial HTML now includes:
- "Burnish" heading (not "Welcome to Burnish")
- Skeleton server button pills (replaced by real server buttons once JS loads)
- Placeholder divs for tool shortcuts, starter prompts, and hints

This ensures users see a consistent, usable layout from first paint through JS hydration.

## Verification
**Light mode:**
![verify-363-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-363-light-20260412120427.png)
**Dark mode:**
![verify-363-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-363-dark-20260412120433.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification: fresh browser context shows "Showcase" server button with green connected dot, tool shortcuts, and "Available tools" prompt — no "Welcome to Burnish" with "+" icon
- [x] Both light and dark mode verified