### PR TITLE
fix(app): render enum options in generated form dropdowns (#377)

### DIFF
--- a/packages/app/src/drill-down.ts
+++ b/packages/app/src/drill-down.ts
@@ -86,7 +86,7 @@ export function generateFallbackForm(
             field.placeholder = prop.description;
         }
         if (prop.default !== undefined) field.value = String(prop.default);
-        if (prop.enum) field.options = prop.enum.map(String);
+        if (prop.enum) field.options = prop.enum.map((v: unknown) => ({ value: String(v), label: String(v) }));
         return field;
     });
     if (fields.length === 0) return null;


### PR DESCRIPTION
## Summary
Fixes #377 — Explorer-mode forms now render enum values as selectable options instead of showing an empty "Select..." dropdown.

## Root Cause
`generateFallbackForm` in `packages/app/src/drill-down.ts` serialized each enum parameter as `field.options = prop.enum.map(String)` — a plain `string[]`. The `burnish-form` component expects `Array<{ value: string; label: string }>` and its Lit template iterates `f.options.map(o => html\`<option value="${o.value}">${o.label}</option>\`)`. With bare strings, `o.value` / `o.label` were `undefined`, so Lit rendered empty `<option>` elements and users only ever saw the placeholder.

This broke every MCP tool with an enum parameter — a launch blocker for Explorer mode.

## Fix / Changes
One-line change in `generateFallbackForm`: map each enum entry to `{ value, label }`. Smallest correct change — no refactor, no schema-shape changes elsewhere.

## Verification
Captured with Playwright against the demo's `create-bug-report` tool (`severity: z.enum(["low","medium","high","critical"])`). The `<select>` was expanded via the `size` attribute so options are visible in the headless screenshot. Shadow-DOM option labels logged during capture: `['Select...', 'low', 'medium', 'high', 'critical']` in both themes.

**Light mode:**
![verify-377-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-377-light-20260412151345.png)

**Dark mode:**
![verify-377-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-377-dark-20260412151348.png)

## Test Plan
- [x] `pnpm build` passes (zero TypeScript errors)
- [ ] CI tests pass (automated on PR)
- [x] Visual verification screenshots confirm fix in light + dark mode
