### PR TITLE
feat(cli): opt-in anonymous telemetry ping (#382)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,29 @@ burnish/
 
 Burnish reads the MCP server's tool list, generates forms from JSON Schema, and maps results directly to components — no LLM in the loop. Everything runs locally.
 
+## Privacy & Telemetry
+
+Burnish collects **opt-in**, anonymous telemetry to measure real adoption (see [issue #382](https://github.com/danfking/burnish/issues/382)). It is **off by default**. On the first interactive run of the CLI you'll see a prompt asking whether to enable it — pressing Enter or anything other than `y` keeps it off.
+
+**What we send (only if you opt in):**
+
+- `v` — burnish CLI version
+- `os` — OS family: `darwin`, `linux`, `win32`, or `other`
+- `node` — Node.js major version
+- `bucket` — coarse invocation-count bucket: `1`, `2-5`, `6-20`, or `21+`
+- `id` — a random install ID (UUID) generated once on first opt-in
+
+**What we never send:** server URLs, tool names, schemas, arguments, file paths, hostnames, usernames, IP addresses we can see beyond the TCP connection, or any content from your MCP servers. There is no per-tool or per-schema tracking.
+
+**How to opt out at any time:**
+
+1. Set the environment variable `BURNISH_TELEMETRY=0` (also accepts `false`, `off`, `no`). This overrides any stored choice.
+2. Or delete / edit the stored choice file:
+   - macOS / Linux: `~/.config/burnish/telemetry.json` (honors `$XDG_CONFIG_HOME`)
+   - Windows: `%APPDATA%\burnish\telemetry.json`
+
+Telemetry is a single fire-and-forget HTTPS POST with a short timeout. If the endpoint is unreachable, the CLI behaves identically — nothing is retried or queued. Telemetry is skipped entirely in non-interactive and CI environments when no choice has been stored.
+
 ## License
 
 [AGPL-3.0](LICENSE) — Daniel King ([@danfking](https://github.com/danfking))

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Burnish collects **opt-in**, anonymous telemetry to measure real adoption (see [
 - `node` — Node.js major version
 - `bucket` — coarse invocation-count bucket: `1`, `2-5`, `6-20`, or `21+`
 - `id` — a random install ID (UUID) generated once on first opt-in
+- `schema_version` — payload schema version (currently `"1"`)
 
 **What we never send:** server URLs, tool names, schemas, arguments, file paths, hostnames, usernames, IP addresses we can see beyond the TCP connection, or any content from your MCP servers. There is no per-tool or per-schema tracking.
 
@@ -372,7 +373,7 @@ Burnish collects **opt-in**, anonymous telemetry to measure real adoption (see [
    - macOS / Linux: `~/.config/burnish/telemetry.json` (honors `$XDG_CONFIG_HOME`)
    - Windows: `%APPDATA%\burnish\telemetry.json`
 
-Telemetry is a single fire-and-forget HTTPS POST with a short timeout. If the endpoint is unreachable, the CLI behaves identically — nothing is retried or queued. Telemetry is skipped entirely in non-interactive and CI environments when no choice has been stored.
+Telemetry is a single fire-and-forget HTTPS POST to `https://burnish-demo.fly.dev/telemetry/v1/ping` with a short timeout. If the endpoint is unreachable, the CLI behaves identically — nothing is retried or queued. Telemetry is skipped entirely in non-interactive and CI environments when no choice has been stored.
 
 ## License
 

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -102,6 +102,134 @@ app.use('/api/tools/execute', async (c, next) => {
     await next();
 });
 
+// --- Telemetry ingestion (burnish CLI opt-in pings) ---
+//
+// Accepts anonymous opt-in telemetry from the burnish CLI (see
+// packages/cli/src/telemetry.ts and issue #382). There is intentionally no
+// persistent storage for v1.0 — we log validated payloads to stdout as a
+// single JSON line prefixed with `telemetry_ping ` so they are greppable in
+// `fly logs`. A real datastore can be swapped in later if volume warrants it.
+//
+// The route deliberately sits outside `/api/*` so that the optional
+// BURNISH_API_KEY Bearer auth does NOT apply — the CLI has no credentials.
+
+const TELEMETRY_RATE_LIMIT_MAX = 60; // 60 pings/min per IP
+const TELEMETRY_RATE_WINDOW_MS = 60_000;
+const TELEMETRY_MAX_BODY_BYTES = 1024; // 1KB hard cap
+
+interface TelemetryBucket {
+    tokens: number;
+    lastRefill: number;
+}
+const telemetryBuckets = new Map<string, TelemetryBucket>();
+
+function evictOldestTelemetryBucket(): void {
+    if (telemetryBuckets.size >= RATE_BUCKET_MAX_ENTRIES) {
+        const oldestKey = telemetryBuckets.keys().next().value;
+        if (oldestKey) telemetryBuckets.delete(oldestKey);
+    }
+}
+
+function checkTelemetryRateLimit(ip: string): boolean {
+    const now = Date.now();
+    let bucket = telemetryBuckets.get(ip);
+    if (!bucket) {
+        evictOldestTelemetryBucket();
+        bucket = { tokens: TELEMETRY_RATE_LIMIT_MAX, lastRefill: now };
+        telemetryBuckets.set(ip, bucket);
+    }
+    const elapsed = now - bucket.lastRefill;
+    const refill = Math.floor(elapsed / TELEMETRY_RATE_WINDOW_MS) * TELEMETRY_RATE_LIMIT_MAX;
+    if (refill > 0) {
+        bucket.tokens = Math.min(TELEMETRY_RATE_LIMIT_MAX, bucket.tokens + refill);
+        bucket.lastRefill = now;
+    }
+    if (bucket.tokens <= 0) return false;
+    bucket.tokens--;
+    return true;
+}
+
+const TELEMETRY_ALLOWED_KEYS = new Set(['v', 'os', 'node', 'bucket', 'id', 'schema_version']);
+const TELEMETRY_ALLOWED_OS = new Set(['darwin', 'linux', 'win32', 'other']);
+const TELEMETRY_ALLOWED_BUCKETS = new Set(['1', '2-5', '6-20', '21+']);
+
+function validateTelemetryPayload(body: unknown): string | null {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+        return 'payload must be a JSON object';
+    }
+    const obj = body as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    for (const k of keys) {
+        if (!TELEMETRY_ALLOWED_KEYS.has(k)) return `unexpected field: ${k}`;
+    }
+    for (const required of TELEMETRY_ALLOWED_KEYS) {
+        if (!(required in obj)) return `missing field: ${required}`;
+    }
+    if (typeof obj.v !== 'string' || obj.v.length > 32) return 'v must be a short string';
+    if (typeof obj.os !== 'string' || !TELEMETRY_ALLOWED_OS.has(obj.os)) return 'os invalid';
+    if (typeof obj.node !== 'string' || obj.node.length > 8) return 'node must be a short string';
+    if (typeof obj.bucket !== 'string' || !TELEMETRY_ALLOWED_BUCKETS.has(obj.bucket)) return 'bucket invalid';
+    if (typeof obj.id !== 'string' || obj.id.length < 8 || obj.id.length > 64) return 'id invalid';
+    if (typeof obj.schema_version !== 'string' || obj.schema_version.length > 8) return 'schema_version invalid';
+    return null;
+}
+
+// CORS preflight — allow POST from any origin (CLI is the main caller but
+// other tools may legitimately ping).
+app.options('/telemetry/v1/ping', (c) => {
+    c.header('Access-Control-Allow-Origin', '*');
+    c.header('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    c.header('Access-Control-Allow-Headers', 'content-type');
+    c.header('Access-Control-Max-Age', '86400');
+    return c.body(null, 204);
+});
+
+app.post('/telemetry/v1/ping', async (c) => {
+    c.header('Access-Control-Allow-Origin', '*');
+
+    const ip = getClientIp(c.req.raw, c.req.raw.headers);
+    if (!checkTelemetryRateLimit(ip)) {
+        return c.json({ error: 'Too many requests' }, 429);
+    }
+
+    // Enforce 1KB cap before parsing JSON.
+    const lenHeader = c.req.header('content-length');
+    if (lenHeader) {
+        const len = parseInt(lenHeader, 10);
+        if (!isNaN(len) && len > TELEMETRY_MAX_BODY_BYTES) {
+            return c.json({ error: 'payload too large' }, 413);
+        }
+    }
+
+    let raw: string;
+    try {
+        raw = await c.req.text();
+    } catch {
+        return c.json({ error: 'invalid body' }, 400);
+    }
+    if (raw.length > TELEMETRY_MAX_BODY_BYTES) {
+        return c.json({ error: 'payload too large' }, 413);
+    }
+
+    let body: unknown;
+    try {
+        body = JSON.parse(raw);
+    } catch {
+        return c.json({ error: 'invalid JSON' }, 400);
+    }
+
+    const validationError = validateTelemetryPayload(body);
+    if (validationError) {
+        return c.json({ error: validationError }, 400);
+    }
+
+    // Structured single-line log for `fly logs | grep telemetry_ping`.
+    // No IP is logged — we only use it for rate limiting, then drop it.
+    console.log('telemetry_ping ' + JSON.stringify({ ...(body as Record<string, unknown>), at: new Date().toISOString() }));
+
+    return c.body(null, 204);
+});
+
 // --- API Routes ---
 
 const startedAt = Date.now();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { startServer } from './server.js';
 import { exportSchema } from './export.js';
 import { formatMcpError } from './errors.js';
+import { runTelemetry } from './telemetry.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_VERSION = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8')).version;
@@ -141,6 +142,10 @@ async function main() {
         printHelp();
         process.exit(1);
     }
+
+    // Opt-in anonymous telemetry. Prompts once on first run, then persists.
+    // BURNISH_TELEMETRY=0 disables. Never blocks or throws — see telemetry.ts.
+    await runTelemetry(PKG_VERSION);
 
     if (opts.command === 'export') {
         await exportSchema(opts);

--- a/packages/cli/src/telemetry.test.ts
+++ b/packages/cli/src/telemetry.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildPayload, configFilePath, envDisabled } from './telemetry.js';
+
+describe('telemetry', () => {
+    let tmp: string;
+    const origEnv = { ...process.env };
+
+    beforeEach(() => {
+        tmp = mkdtempSync(join(tmpdir(), 'burnish-telemetry-test-'));
+        process.env.BURNISH_CONFIG_DIR = tmp;
+        delete process.env.BURNISH_TELEMETRY;
+    });
+
+    afterEach(() => {
+        rmSync(tmp, { recursive: true, force: true });
+        process.env = { ...origEnv };
+    });
+
+    describe('envDisabled', () => {
+        it('returns false when unset', () => {
+            delete process.env.BURNISH_TELEMETRY;
+            expect(envDisabled()).toBe(false);
+        });
+
+        it('returns true for 0 / false / off / no', () => {
+            for (const v of ['0', 'false', 'off', 'no', 'FALSE', 'Off']) {
+                process.env.BURNISH_TELEMETRY = v;
+                expect(envDisabled()).toBe(true);
+            }
+        });
+
+        it('returns false for 1 / true', () => {
+            process.env.BURNISH_TELEMETRY = '1';
+            expect(envDisabled()).toBe(false);
+            process.env.BURNISH_TELEMETRY = 'true';
+            expect(envDisabled()).toBe(false);
+        });
+    });
+
+    describe('configFilePath', () => {
+        it('honors BURNISH_CONFIG_DIR override', () => {
+            expect(configFilePath()).toBe(join(tmp, 'telemetry.json'));
+        });
+    });
+
+    describe('buildPayload', () => {
+        it('includes all required fields and nothing else', () => {
+            const p = buildPayload('1.2.3', 'abc-id', 1);
+            expect(Object.keys(p).sort()).toEqual(['bucket', 'id', 'node', 'os', 'v']);
+            expect(p.v).toBe('1.2.3');
+            expect(p.id).toBe('abc-id');
+            expect(['darwin', 'linux', 'win32', 'other']).toContain(p.os);
+            expect(p.node).toMatch(/^\d+$/);
+        });
+
+        it('buckets counts coarsely', () => {
+            expect(buildPayload('0', 'x', 1).bucket).toBe('1');
+            expect(buildPayload('0', 'x', 2).bucket).toBe('2-5');
+            expect(buildPayload('0', 'x', 5).bucket).toBe('2-5');
+            expect(buildPayload('0', 'x', 6).bucket).toBe('6-20');
+            expect(buildPayload('0', 'x', 20).bucket).toBe('6-20');
+            expect(buildPayload('0', 'x', 21).bucket).toBe('21+');
+            expect(buildPayload('0', 'x', 9999).bucket).toBe('21+');
+        });
+
+        it('never includes hostname, username, schema, or path fields', () => {
+            const p = buildPayload('1.0.0', 'id', 3) as unknown as Record<string, unknown>;
+            for (const forbidden of ['host', 'hostname', 'user', 'username', 'cwd', 'path', 'schema', 'tools']) {
+                expect(p[forbidden]).toBeUndefined();
+            }
+        });
+    });
+});

--- a/packages/cli/src/telemetry.test.ts
+++ b/packages/cli/src/telemetry.test.ts
@@ -49,11 +49,12 @@ describe('telemetry', () => {
     describe('buildPayload', () => {
         it('includes all required fields and nothing else', () => {
             const p = buildPayload('1.2.3', 'abc-id', 1);
-            expect(Object.keys(p).sort()).toEqual(['bucket', 'id', 'node', 'os', 'v']);
+            expect(Object.keys(p).sort()).toEqual(['bucket', 'id', 'node', 'os', 'schema_version', 'v']);
             expect(p.v).toBe('1.2.3');
             expect(p.id).toBe('abc-id');
             expect(['darwin', 'linux', 'win32', 'other']).toContain(p.os);
             expect(p.node).toMatch(/^\d+$/);
+            expect(p.schema_version).toBe('1');
         });
 
         it('buckets counts coarsely', () => {

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -17,8 +17,15 @@
  * - **Fire-and-forget.** A single HTTPS POST with a short timeout. All errors
  *   are swallowed. Telemetry never blocks CLI startup.
  *
- * TODO(danfking): wire the real endpoint before v1.0 ships. The placeholder
- * below is not provisioned. Until it is, failed pings are silent no-ops.
+ * The ingestion endpoint is a `POST /telemetry/v1/ping` route on the
+ * existing burnish-demo Fly app (apps/demo/server/index.ts). For v1.0 the
+ * "backend" is just `fly logs | grep telemetry_ping` — validated payloads
+ * are logged as single JSON lines. A real datastore can be added later.
+ *
+ * TODO(danfking): after merging this PR, run `flyctl deploy` against the
+ * burnish-demo app so the new `/telemetry/v1/ping` route is live. Until
+ * the updated image is deployed, CLI pings will 404 and be silently dropped
+ * (which is fine — the CLI swallows all errors).
  */
 
 import { randomUUID } from 'node:crypto';
@@ -27,9 +34,11 @@ import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 
-// Placeholder — not provisioned yet. See TODO at top of file.
-const TELEMETRY_ENDPOINT = 'https://telemetry.burnish.dev/v1/ping';
+// Ingestion route on the burnish-demo Fly app. See apps/demo/server/index.ts
+// and the TODO at the top of this file regarding deployment.
+const TELEMETRY_ENDPOINT = 'https://burnish-demo.fly.dev/telemetry/v1/ping';
 const TELEMETRY_TIMEOUT_MS = 1500;
+const TELEMETRY_SCHEMA_VERSION = '1';
 
 export type TelemetryDecision = 'enabled' | 'disabled';
 
@@ -171,6 +180,7 @@ export interface TelemetryPayload {
     node: string;
     bucket: '1' | '2-5' | '6-20' | '21+';
     id: string;
+    schema_version: string;
 }
 
 export function buildPayload(version: string, id: string, count: number): TelemetryPayload {
@@ -180,6 +190,7 @@ export function buildPayload(version: string, id: string, count: number): Teleme
         node: String(process.versions.node.split('.')[0] || 'unknown'),
         bucket: countBucket(count),
         id,
+        schema_version: TELEMETRY_SCHEMA_VERSION,
     };
 }
 

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,0 +1,245 @@
+/**
+ * Opt-in anonymous telemetry for the burnish CLI.
+ *
+ * Design goals (see FINANCIAL-TARGETS.md §5 and issue #382):
+ * - **Opt-in only.** First invocation shows a disclosure prompt. Choice is
+ *   persisted in the user's config directory (never in CWD).
+ * - **Trivially disabled.** `BURNISH_TELEMETRY=0` (or `false`/`off`/`no`)
+ *   disables regardless of stored choice. The prompt is also skipped in
+ *   non-interactive environments and in CI.
+ * - **Anonymous + minimal.** The only fields ever sent are:
+ *     - `v`: burnish CLI version (e.g. "0.1.1")
+ *     - `os`: OS family — one of "darwin" | "linux" | "win32" | "other"
+ *     - `node`: Node major version (e.g. "20")
+ *     - `bucket`: coarse invocation count bucket — "1" | "2-5" | "6-20" | "21+"
+ *     - `id`: anonymous random install ID (UUID v4) generated on first opt-in
+ *   No hostnames. No usernames. No schemas. No server URLs. No per-tool data.
+ * - **Fire-and-forget.** A single HTTPS POST with a short timeout. All errors
+ *   are swallowed. Telemetry never blocks CLI startup.
+ *
+ * TODO(danfking): wire the real endpoint before v1.0 ships. The placeholder
+ * below is not provisioned. Until it is, failed pings are silent no-ops.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+
+// Placeholder — not provisioned yet. See TODO at top of file.
+const TELEMETRY_ENDPOINT = 'https://telemetry.burnish.dev/v1/ping';
+const TELEMETRY_TIMEOUT_MS = 1500;
+
+export type TelemetryDecision = 'enabled' | 'disabled';
+
+interface TelemetryConfig {
+    /** User's stored opt-in choice. */
+    decision: TelemetryDecision;
+    /** Anonymous random install ID, only set if decision === 'enabled'. */
+    id?: string;
+    /** Total invocations since opt-in (used only to compute the coarse bucket). */
+    count: number;
+    /** ISO timestamp the choice was made — purely local, never transmitted. */
+    chosenAt: string;
+}
+
+/** Return the path to the burnish CLI config directory (XDG-ish). */
+function configDir(): string {
+    if (process.env.BURNISH_CONFIG_DIR) {
+        return process.env.BURNISH_CONFIG_DIR;
+    }
+    const home = homedir();
+    if (process.platform === 'win32') {
+        const appData = process.env.APPDATA || join(home, 'AppData', 'Roaming');
+        return join(appData, 'burnish');
+    }
+    const xdg = process.env.XDG_CONFIG_HOME || join(home, '.config');
+    return join(xdg, 'burnish');
+}
+
+export function configFilePath(): string {
+    return join(configDir(), 'telemetry.json');
+}
+
+function readConfig(): TelemetryConfig | null {
+    try {
+        const p = configFilePath();
+        if (!existsSync(p)) return null;
+        const raw = readFileSync(p, 'utf-8');
+        const parsed = JSON.parse(raw) as Partial<TelemetryConfig>;
+        if (parsed.decision !== 'enabled' && parsed.decision !== 'disabled') {
+            return null;
+        }
+        return {
+            decision: parsed.decision,
+            id: typeof parsed.id === 'string' ? parsed.id : undefined,
+            count: typeof parsed.count === 'number' ? parsed.count : 0,
+            chosenAt: typeof parsed.chosenAt === 'string' ? parsed.chosenAt : new Date().toISOString(),
+        };
+    } catch {
+        return null;
+    }
+}
+
+function writeConfig(cfg: TelemetryConfig): void {
+    try {
+        const p = configFilePath();
+        mkdirSync(dirname(p), { recursive: true });
+        writeFileSync(p, JSON.stringify(cfg, null, 2), 'utf-8');
+    } catch {
+        // Never fail the CLI because of telemetry bookkeeping.
+    }
+}
+
+/** Is telemetry forcibly disabled via env var? */
+export function envDisabled(): boolean {
+    const v = process.env.BURNISH_TELEMETRY;
+    if (v === undefined) return false;
+    const lower = v.trim().toLowerCase();
+    return lower === '0' || lower === 'false' || lower === 'off' || lower === 'no';
+}
+
+function isCi(): boolean {
+    // Common CI env flags. Be conservative: never prompt in CI.
+    return Boolean(
+        process.env.CI ||
+        process.env.GITHUB_ACTIONS ||
+        process.env.GITLAB_CI ||
+        process.env.CIRCLECI ||
+        process.env.BUILDKITE ||
+        process.env.TRAVIS
+    );
+}
+
+function isInteractive(): boolean {
+    return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function osFamily(): 'darwin' | 'linux' | 'win32' | 'other' {
+    const p = platform();
+    if (p === 'darwin' || p === 'linux' || p === 'win32') return p;
+    return 'other';
+}
+
+function countBucket(count: number): '1' | '2-5' | '6-20' | '21+' {
+    if (count <= 1) return '1';
+    if (count <= 5) return '2-5';
+    if (count <= 20) return '6-20';
+    return '21+';
+}
+
+/**
+ * Show the first-run disclosure and return the user's choice.
+ * Default on empty/unknown answer is 'disabled' (opt-in, not opt-out).
+ */
+async function promptForConsent(): Promise<TelemetryDecision> {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+        process.stdout.write(
+            '\n' +
+            'burnish: help improve the project with anonymous telemetry?\n' +
+            '\n' +
+            '  We send a single ping per invocation containing:\n' +
+            '    - burnish version\n' +
+            '    - OS family (darwin / linux / win32)\n' +
+            '    - Node major version\n' +
+            '    - a coarse invocation-count bucket (1, 2-5, 6-20, 21+)\n' +
+            '    - a random install ID generated on first opt-in\n' +
+            '\n' +
+            '  We never send: server URLs, tool names, schemas, file paths,\n' +
+            '  hostnames, usernames, or any content from your MCP servers.\n' +
+            '\n' +
+            '  You can change your mind anytime by editing or deleting:\n' +
+            `    ${configFilePath()}\n` +
+            '  or by setting BURNISH_TELEMETRY=0 in your environment.\n' +
+            '\n'
+        );
+        const answer = (await rl.question('Enable anonymous telemetry? [y/N]: ')).trim().toLowerCase();
+        return answer === 'y' || answer === 'yes' ? 'enabled' : 'disabled';
+    } catch {
+        return 'disabled';
+    } finally {
+        rl.close();
+    }
+}
+
+/** The exact JSON shape sent to the telemetry endpoint. */
+export interface TelemetryPayload {
+    v: string;
+    os: 'darwin' | 'linux' | 'win32' | 'other';
+    node: string;
+    bucket: '1' | '2-5' | '6-20' | '21+';
+    id: string;
+}
+
+export function buildPayload(version: string, id: string, count: number): TelemetryPayload {
+    return {
+        v: version,
+        os: osFamily(),
+        node: String(process.versions.node.split('.')[0] || 'unknown'),
+        bucket: countBucket(count),
+        id,
+    };
+}
+
+/** Fire-and-forget ping. Never throws, never blocks beyond the short timeout. */
+async function sendPing(payload: TelemetryPayload): Promise<void> {
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+        try {
+            await fetch(TELEMETRY_ENDPOINT, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(payload),
+                signal: controller.signal,
+            });
+        } finally {
+            clearTimeout(timer);
+        }
+    } catch {
+        // Silent: endpoint may not be provisioned, offline, etc.
+    }
+}
+
+/**
+ * Run telemetry for this invocation.
+ *
+ * - Honors `BURNISH_TELEMETRY=0`.
+ * - Prompts once on first interactive run, then persists the choice.
+ * - If enabled, bumps the local invocation counter and fires a single
+ *   non-blocking ping.
+ *
+ * Safe to call unconditionally from CLI startup. All errors are swallowed.
+ */
+export async function runTelemetry(version: string): Promise<void> {
+    try {
+        if (envDisabled()) return;
+
+        let cfg = readConfig();
+
+        if (!cfg) {
+            // No stored choice yet. Only prompt in interactive, non-CI sessions.
+            if (!isInteractive() || isCi()) return;
+            const decision = await promptForConsent();
+            cfg = {
+                decision,
+                id: decision === 'enabled' ? randomUUID() : undefined,
+                count: 0,
+                chosenAt: new Date().toISOString(),
+            };
+            writeConfig(cfg);
+        }
+
+        if (cfg.decision !== 'enabled' || !cfg.id) return;
+
+        cfg.count += 1;
+        writeConfig(cfg);
+
+        // Fire-and-forget. We do NOT await the ping against CLI startup.
+        void sendPing(buildPayload(version, cfg.id, cfg.count));
+    } catch {
+        // Never let telemetry break the CLI.
+    }
+}


### PR DESCRIPTION
## Summary
Closes #382.

Adds a minimal, **opt-in** anonymous telemetry path to the `burnish` CLI plus the ingestion route it posts to on the existing `burnish-demo` Fly app. Purpose: measure unique invocations for the v1.0 leading-indicator table (FINANCIAL-TARGETS.md §5 — telemetry is pre-committed to ship with v1.0).

## Design

### Opt-in on first run (CLI)
- On the first interactive invocation the CLI shows a clear disclosure listing exactly what is and isn't collected, then prompts `Enable anonymous telemetry? [y/N]`. Default is **off** — anything other than `y`/`yes` stores a `disabled` choice.
- Prompt is skipped entirely in non-interactive environments (`!stdin.isTTY`) and in CI (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `BUILDKITE`, `TRAVIS`).
- Choice persisted in the user's config directory, **not CWD**:
  - macOS / Linux: `$XDG_CONFIG_HOME/burnish/telemetry.json` (fallback `~/.config/burnish/telemetry.json`)
  - Windows: `%APPDATA%\burnish\telemetry.json`
  - Tests can override with `BURNISH_CONFIG_DIR`.

### Opt-out
- `BURNISH_TELEMETRY=0` (also `false`/`off`/`no`) disables telemetry **regardless of stored choice**.
- Users can also delete or edit `telemetry.json`.

### Payload (exact JSON shape sent)
```json
{
  "v": "0.1.1",
  "os": "darwin" | "linux" | "win32" | "other",
  "node": "20",
  "bucket": "1" | "2-5" | "6-20" | "21+",
  "id": "<uuid-v4>",
  "schema_version": "1"
}
```
- `id` is a random UUID generated once on first opt-in. Stable (not rotated), per danfking.
- `bucket` is coarse; we never send the raw count.
- `schema_version` is a string (`"1"`) so future schema changes are cheap.
- **Never sent:** hostnames, usernames, CWD, file paths, server URLs, tool names, schemas, arguments, or any MCP content.

### Transport (CLI)
- Single `fetch` POST `content-type: application/json` to **`https://burnish-demo.fly.dev/telemetry/v1/ping`**.
- 1.5s `AbortController` timeout. All errors swallowed. `void sendPing(...)` is not awaited.

### Ingestion route (`apps/demo/server/index.ts`)
- **Route:** `POST /telemetry/v1/ping` on the existing `burnish-demo` Fly app. Deliberately outside `/api/*` so the optional `BURNISH_API_KEY` Bearer guard does not apply.
- **Validation:** strict key allowlist (`v`, `os`, `node`, `bucket`, `id`, `schema_version`). Unexpected or missing key → 400. Per-field type + enum checks.
- **Size cap:** 1KB hard limit via `content-length` header and raw-body length. Oversized → 413.
- **Rate limit:** per-IP in-memory token bucket, **60 pings/min**. IPs are used only for rate-limiting and are **never logged**.
- **CORS:** `Access-Control-Allow-Origin: *` on POST and OPTIONS.
- **Response:** `204 No Content` with empty body.
- **Backend = Fly logs.** Validated payloads logged to stdout as a single JSON line prefixed with `telemetry_ping ` so they are greppable in `fly logs`. **No persistent storage for v1.0** — a real datastore can be swapped in later if volume justifies it.

## Files
- `packages/cli/src/telemetry.ts` — CLI telemetry module (endpoint, `schema_version: "1"`, fire-and-forget POST, config persistence, consent prompt).
- `packages/cli/src/telemetry.test.ts` — unit tests (including `schema_version` in allowed keys).
- `packages/cli/src/cli.ts` — calls `await runTelemetry(PKG_VERSION)` after arg validation.
- `apps/demo/server/index.ts` — new `POST /telemetry/v1/ping` + `OPTIONS` preflight, validation, 1KB cap, 60/min per-IP rate limit, structured stdout log.
- `README.md` — "Privacy & Telemetry" section (field list incl. `schema_version`, endpoint URL, opt-out mechanisms, config file locations).

## Verification
- `pnpm build` passes
- `pnpm vitest run packages/cli/src/telemetry.test.ts` — 7/7 passing
- Local smoke test against the demo server on port 8123:
  - Valid payload → **204**, log line: `telemetry_ping {"v":"0.1.1","os":"linux","node":"20","bucket":"1","id":"11111111-2222-3333-4444-555555555555","schema_version":"1","at":"..."}`
  - Missing `schema_version` → **400** `{"error":"missing field: schema_version"}`
  - Unexpected field `evil` → **400** `{"error":"unexpected field: evil"}`
  - Invalid `os` (`"BeOS"`) → **400** `{"error":"os invalid"}`
  - 2KB payload → **413** `{"error":"payload too large"}`

Not a visual change — no screenshots needed.

## Test Plan
- [x] `pnpm build` passes
- [x] CLI telemetry unit tests pass
- [x] Local smoke test against new route (204 + rejection paths + log line)
- [ ] CI tests pass (automated on PR)
- [ ] **TODO(danfking):** run `flyctl deploy` on `burnish-demo` from `deploy/demo/` so the new `/telemetry/v1/ping` route is live before launch. The agent does **not** run `flyctl deploy`. Until the updated image is deployed, CLI pings will 404 and be silently dropped — harmless because the CLI swallows all errors.

## Resolved open questions
1. Endpoint — reuse `burnish-demo` Fly app; new route on existing server. Done.
2. `schema_version` — added as a **string** (`"1"`). Done.
3. Consent prompt copy — approved as-is.
4. Install ID rotation — keep stable. No change.
5. `burnish telemetry` subcommand — deferred to v1.1. No change.