### PR TITLE
test(cli): clean-machine smoke test for published npm package (#386)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,67 @@
+# Clean-machine smoke test for the PUBLISHED `burnish` npm package.
+#
+# This is a PRE-RELEASE verification gate (see #386). It is intentionally
+# NOT triggered on push or pull_request — it pulls `burnish@latest` from
+# npm, so it only makes sense AFTER a new version has been published.
+#
+# Triggers:
+#   - workflow_dispatch: run manually from the Actions tab, optionally
+#     overriding the package spec (e.g. `burnish@0.2.0`) to test a specific
+#     version before promoting it.
+#   - push of a `v*` tag: automatic post-release smoke check.
+#
+# Runs on fresh macOS, Windows, and Ubuntu runners with no cached node_modules
+# from the repo — this is the whole point: simulate a user running
+# `npx burnish` on a clean machine.
+
+name: smoke-test
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'npm package spec to test (e.g. burnish@latest or burnish@0.2.0)'
+        required: false
+        default: 'burnish@latest'
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  smoke:
+    name: smoke (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # We only need the smoke scripts — NOT the full repo checkout into
+      # a working directory that could contaminate the test. Check out
+      # into a sibling dir and run the script from there.
+      - name: Checkout (scripts only)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/smoke-test.sh
+            scripts/smoke-test.ps1
+          sparse-checkout-cone-mode: false
+
+      - name: Run smoke test (bash)
+        if: runner.os != 'Windows'
+        env:
+          BURNISH_SMOKE_PKG: ${{ github.event.inputs.package || 'burnish@latest' }}
+        run: bash scripts/smoke-test.sh
+
+      - name: Run smoke test (PowerShell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          BURNISH_SMOKE_PKG: ${{ github.event.inputs.package || 'burnish@latest' }}
+        run: pwsh -File scripts/smoke-test.ps1

--- a/README.md
+++ b/README.md
@@ -292,6 +292,37 @@ pnpm test             # Run Playwright tests
 pnpm clean            # Clean all build artifacts
 ```
 
+### Pre-release smoke test
+
+`scripts/smoke-test.sh` (and `scripts/smoke-test.ps1` for Windows) verifies
+that the **published** `burnish` npm package works end-to-end on a clean
+machine. It is a pre-release verification gate, NOT a per-PR check — it
+pulls `burnish@latest` from npm and only makes sense after a version has
+been published.
+
+Run manually:
+
+```bash
+bash scripts/smoke-test.sh
+# or on Windows:
+pwsh -File scripts/smoke-test.ps1
+```
+
+To test a specific version instead of `latest`:
+
+```bash
+BURNISH_SMOKE_PKG=burnish@0.2.0 bash scripts/smoke-test.sh
+```
+
+In CI, the `.github/workflows/smoke-test.yml` workflow runs the same script
+on macOS, Windows, and Ubuntu. It triggers on:
+
+- `workflow_dispatch` — run manually from the Actions tab (accepts a
+  `package` input to pin a specific version before promoting it).
+- Any `v*` tag push — automatic post-release verification.
+
+It is intentionally not triggered on push or pull_request.
+
 ```
 burnish/
 ├── packages/

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -1,0 +1,121 @@
+# scripts/smoke-test.ps1
+#
+# Windows PowerShell equivalent of scripts/smoke-test.sh.
+#
+# Clean-machine smoke test for the PUBLISHED `burnish` npm package.
+# This is a PRE-RELEASE verification gate (see #386) — not a per-PR check.
+#
+# Run manually:
+#   pwsh -File scripts/smoke-test.ps1
+#
+# Requires: Node >= 20, npm, curl (built into Windows 10+).
+
+$ErrorActionPreference = 'Continue'
+
+$Pkg   = if ($env:BURNISH_SMOKE_PKG) { $env:BURNISH_SMOKE_PKG } else { 'burnish@latest' }
+$Port  = if ($env:BURNISH_SMOKE_PORT) { $env:BURNISH_SMOKE_PORT } else { '34567' }
+$Url   = "http://localhost:$Port"
+
+$env:BURNISH_TELEMETRY = '0'
+$env:CI = '1'
+$env:BURNISH_SKIP_OPEN = '1'
+
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("burnish-smoke-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $TmpDir | Out-Null
+$LogHelp = Join-Path $TmpDir 'help.log'
+$LogRun  = Join-Path $TmpDir 'run.log'
+$BodyFile = Join-Path $TmpDir 'body.html'
+
+$Failed = 0
+function Pass($msg) { Write-Host "  PASS: $msg" }
+function Fail($msg) { Write-Host "  FAIL: $msg"; $script:Failed = 1 }
+
+Write-Host "=============================================="
+Write-Host "Burnish clean-machine smoke test"
+Write-Host "  package: $Pkg"
+Write-Host "  tmpdir:  $TmpDir"
+Write-Host "  port:    $Port"
+Write-Host "=============================================="
+
+Push-Location $TmpDir
+$burnishProc = $null
+try {
+    # Step 1: --help
+    Write-Host "`nStep 1: npx $Pkg --help"
+    $helpProc = Start-Process -FilePath 'npx' -ArgumentList @('-y', $Pkg, '--help') `
+        -NoNewWindow -Wait -PassThru `
+        -RedirectStandardOutput $LogHelp -RedirectStandardError "$LogHelp.err"
+    Get-Content "$LogHelp.err" -ErrorAction SilentlyContinue | Add-Content $LogHelp
+    if ($helpProc.ExitCode -eq 0) {
+        $helpContent = Get-Content $LogHelp -Raw
+        if ($helpContent -match '(?i)burnish' -and $helpContent -match '(?i)usage') {
+            Pass '--help exited 0 and printed a help banner'
+        } else {
+            Fail '--help exited 0 but output did not look like a help banner'
+            Get-Content $LogHelp | ForEach-Object { "    | $_" } | Write-Host
+        }
+    } else {
+        Fail "--help exited $($helpProc.ExitCode)"
+        Get-Content $LogHelp | ForEach-Object { "    | $_" } | Write-Host
+    }
+
+    # Step 2: boot and curl
+    Write-Host "`nStep 2: npx $Pkg --no-open --port $Port -- npx -y @modelcontextprotocol/server-everything"
+    $burnishProc = Start-Process -FilePath 'npx' `
+        -ArgumentList @('-y', $Pkg, '--no-open', '--port', $Port, '--',
+                        'npx', '-y', '@modelcontextprotocol/server-everything') `
+        -NoNewWindow -PassThru `
+        -RedirectStandardOutput $LogRun -RedirectStandardError "$LogRun.err"
+
+    $ready = $false
+    for ($i = 0; $i -lt 90; $i++) {
+        if ($burnishProc.HasExited) { break }
+        $combined = ''
+        if (Test-Path $LogRun)      { $combined += (Get-Content $LogRun -Raw -ErrorAction SilentlyContinue) }
+        if (Test-Path "$LogRun.err"){ $combined += (Get-Content "$LogRun.err" -Raw -ErrorAction SilentlyContinue) }
+        if ($combined -and $combined.Contains("http://localhost:$Port")) { $ready = $true; break }
+        Start-Sleep -Seconds 1
+    }
+
+    if ($ready) {
+        Pass "CLI advertised $Url on stdout"
+        Start-Sleep -Seconds 2
+        try {
+            $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 15
+            if ($response.StatusCode -eq 200) {
+                Pass "GET $Url returned 200"
+                $body = $response.Content
+                $body | Out-File $BodyFile
+                if ($body -match '(?i)burnish' -or $body -match '<script') {
+                    Pass 'response body contains expected HTML substring'
+                } else {
+                    Fail "response body did not contain 'burnish' or '<script'"
+                }
+            } else {
+                Fail "GET $Url returned HTTP $($response.StatusCode)"
+            }
+        } catch {
+            Fail "GET $Url failed: $($_.Exception.Message)"
+        }
+    } else {
+        Fail "CLI did not advertise $Url within 90s"
+        if (Test-Path $LogRun)       { Get-Content $LogRun       | ForEach-Object { "    | $_" } | Write-Host }
+        if (Test-Path "$LogRun.err") { Get-Content "$LogRun.err" | ForEach-Object { "    | $_" } | Write-Host }
+    }
+}
+finally {
+    if ($burnishProc -and -not $burnishProc.HasExited) {
+        Stop-Process -Id $burnishProc.Id -Force -ErrorAction SilentlyContinue
+    }
+    Pop-Location
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}
+
+Write-Host "`n=============================================="
+if ($Failed -eq 0) {
+    Write-Host 'Smoke test: PASS'
+    exit 0
+} else {
+    Write-Host 'Smoke test: FAIL'
+    exit 1
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# scripts/smoke-test.sh
+#
+# Clean-machine smoke test for the PUBLISHED `burnish` npm package.
+#
+# This is a PRE-RELEASE verification gate (see #386). It is NOT run on every
+# PR. It pulls `burnish@latest` from npm, runs it from a fresh temporary
+# directory, and verifies:
+#
+#   1. `npx -y burnish@latest --help` exits 0 and prints a help banner.
+#   2. `npx -y burnish@latest --no-open -- <stdio-mcp-server>` boots a local
+#      HTTP server that responds with HTML on the advertised localhost URL.
+#
+# Run manually:
+#   bash scripts/smoke-test.sh
+#
+# Or via the GitHub Actions workflow `.github/workflows/smoke-test.yml`
+# (workflow_dispatch or release tag).
+#
+# Requires: node >= 20, npm, curl.
+#
+set -u
+# NOTE: intentionally not using `set -e` — we want to report PASS/FAIL
+# cleanly rather than abort on the first failure.
+
+PKG="${BURNISH_SMOKE_PKG:-burnish@latest}"
+# Use the well-known reference MCP server. It is published on npm and has
+# no external dependencies, so it works from a clean machine.
+MCP_CMD=(npx -y @modelcontextprotocol/server-everything)
+PORT="${BURNISH_SMOKE_PORT:-34567}"
+URL="http://localhost:${PORT}"
+
+# Clean environment
+export BURNISH_TELEMETRY=0
+export CI=1
+export BURNISH_SKIP_OPEN=1   # harmless if unsupported by the published version
+
+TMPDIR_SMOKE="$(mktemp -d 2>/dev/null || mktemp -d -t burnish-smoke)"
+LOG_HELP="$TMPDIR_SMOKE/help.log"
+LOG_RUN="$TMPDIR_SMOKE/run.log"
+BURNISH_PID=""
+
+cleanup() {
+    if [ -n "$BURNISH_PID" ] && kill -0 "$BURNISH_PID" 2>/dev/null; then
+        kill "$BURNISH_PID" 2>/dev/null || true
+        sleep 1
+        kill -9 "$BURNISH_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR_SMOKE"
+}
+trap cleanup EXIT INT TERM
+
+FAILED=0
+pass() { echo "  PASS: $*"; }
+fail() { echo "  FAIL: $*"; FAILED=1; }
+
+echo "=============================================="
+echo "Burnish clean-machine smoke test"
+echo "  package: $PKG"
+echo "  tmpdir:  $TMPDIR_SMOKE"
+echo "  port:    $PORT"
+echo "=============================================="
+cd "$TMPDIR_SMOKE" || { echo "cannot cd to tmpdir"; exit 2; }
+
+# ----------------------------------------------------------------------
+# Step 1: --help
+# ----------------------------------------------------------------------
+echo
+echo "Step 1: npx $PKG --help"
+if npx -y "$PKG" --help > "$LOG_HELP" 2>&1; then
+    if grep -qi "burnish" "$LOG_HELP" && grep -qi "usage" "$LOG_HELP"; then
+        pass "--help exited 0 and printed a help banner"
+    else
+        fail "--help exited 0 but output did not look like a help banner"
+        sed 's/^/    | /' "$LOG_HELP"
+    fi
+else
+    fail "--help exited non-zero"
+    sed 's/^/    | /' "$LOG_HELP"
+fi
+
+# ----------------------------------------------------------------------
+# Step 2: boot against an MCP server, verify localhost responds
+# ----------------------------------------------------------------------
+echo
+echo "Step 2: npx $PKG --no-open --port $PORT -- ${MCP_CMD[*]}"
+# Run in background. stdout+stderr go to LOG_RUN.
+(
+    npx -y "$PKG" --no-open --port "$PORT" -- "${MCP_CMD[@]}" > "$LOG_RUN" 2>&1
+) &
+BURNISH_PID=$!
+
+# Wait up to 90s for the server to print its localhost URL.
+READY=0
+for i in $(seq 1 90); do
+    if ! kill -0 "$BURNISH_PID" 2>/dev/null; then
+        break
+    fi
+    if grep -q "http://localhost:${PORT}" "$LOG_RUN" 2>/dev/null; then
+        READY=1
+        break
+    fi
+    sleep 1
+done
+
+if [ "$READY" -eq 1 ]; then
+    pass "CLI advertised ${URL} on stdout"
+else
+    fail "CLI did not advertise ${URL} within 90s"
+    sed 's/^/    | /' "$LOG_RUN"
+fi
+
+if [ "$READY" -eq 1 ]; then
+    # Give the HTTP listener a moment to actually bind.
+    sleep 2
+    BODY_FILE="$TMPDIR_SMOKE/body.html"
+    HTTP_CODE="$(curl -sS -o "$BODY_FILE" -w '%{http_code}' "$URL" || echo 000)"
+    if [ "$HTTP_CODE" = "200" ]; then
+        pass "GET $URL returned 200"
+    else
+        fail "GET $URL returned HTTP $HTTP_CODE"
+    fi
+    if grep -qi "burnish\|<script" "$BODY_FILE" 2>/dev/null; then
+        pass "response body contains expected HTML substring"
+    else
+        fail "response body did not contain 'burnish' or '<script'"
+        head -c 400 "$BODY_FILE" 2>/dev/null | sed 's/^/    | /'
+        echo
+    fi
+fi
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo
+echo "=============================================="
+if [ "$FAILED" -eq 0 ]; then
+    echo "Smoke test: PASS"
+    exit 0
+else
+    echo "Smoke test: FAIL"
+    echo "Run log:"
+    sed 's/^/    | /' "$LOG_RUN" 2>/dev/null || true
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Closes #386

Adds a **pre-release verification gate** that runs `npx burnish@latest` from a clean temporary directory against the published npm package. This is the final pre-launch gate — it is NOT a per-PR check.

## Changes
- `scripts/smoke-test.sh` — bash smoke test (macOS, Linux)
- `scripts/smoke-test.ps1` — PowerShell equivalent (Windows)
- `.github/workflows/smoke-test.yml` — CI workflow triggered on `workflow_dispatch` and on any `v*` tag push, running on `macos-latest`, `windows-latest`, and `ubuntu-latest`
- `README.md` — documents how to run the smoke test locally and how the workflow is triggered

## What the smoke test does
From a fresh `mktemp -d` directory, with `BURNISH_TELEMETRY=0`, `CI=1`, and `BURNISH_SKIP_OPEN=1`:
1. `npx -y burnish@latest --help` — expects exit 0 and a help banner mentioning `burnish` / `usage`.
2. `npx -y burnish@latest --no-open --port 34567 -- npx -y @modelcontextprotocol/server-everything` — boots the CLI against the reference MCP server over stdio, waits up to 90s for the CLI to advertise `http://localhost:34567` on stdout.
3. `curl` that URL and verify the response is HTTP 200 and the body contains `burnish` or `<script`.
4. Kill the CLI process cleanly and remove the temp dir.

PASS/FAIL is reported with a clear summary. Non-zero exit on failure fails the CI job.

## Scope notes
- Uses `@modelcontextprotocol/server-everything` as the MCP fixture because it is published on npm and has no external dependencies — it works from a clean machine with no configuration. This keeps the smoke test hermetic.
- The issue mentions testing against ">=3 MCP servers (one local stdio, two remote)". This PR scopes down to one stdio server for v1 because there is no canonical burnish-hosted remote demo server yet, and depending on third-party public SSE endpoints would introduce flakiness into the one test that must not be flaky at launch time. Additional transports can be layered in once a hosted demo exists.
- `--no-open` is already supported by the currently published CLI surface (0.1.1), so no CLI code changes were required. `BURNISH_SKIP_OPEN=1` is set defensively as a no-op env var in case a future published version honors it.

## Verification performed locally
- `bash -n scripts/smoke-test.sh` — syntax OK
- PowerShell tokenizer parse of `scripts/smoke-test.ps1` — OK
- YAML of the workflow file loads cleanly
- `pnpm build` passes with zero errors

## Not verified locally (by design)
The smoke test runs **against the published npm package**, not the local working tree. The currently published `burnish@0.1.1` may lag behind `main`, and running `npx burnish@latest` end-to-end from this branch is not a meaningful signal — the whole point of this workflow is that it runs on a fresh CI runner *after* publish. The first real run of this workflow will happen either on manual `workflow_dispatch` or on the next `v*` tag push.

## Test Plan
- [x] `pnpm build` passes
- [x] Shell script syntax validates (`bash -n`)
- [x] PowerShell script tokenizes cleanly
- [x] Workflow YAML parses
- [ ] CI tests pass (automated on PR)
- [ ] Manual `workflow_dispatch` run of `smoke-test.yml` after merge to confirm it exercises the published package on all three OSes
