### PR TITLE
ci: auto-deploy demo on push to main (paths-filtered)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -4,6 +4,20 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/demo/**'
+      - 'packages/**'
+      - 'deploy/demo/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'package.json'
+      - '.github/workflows/deploy-demo.yml'
+
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
## Why
Until now `deploy-demo.yml` only ran on `release: published` or manual `workflow_dispatch`. That meant merging #392 (which added the `/telemetry/v1/ping` route to the demo server) did NOT deploy the change — the endpoint would 404 silently until someone remembered to trigger deploy manually.

Now that the demo is effectively production infrastructure (it hosts the telemetry ingestion endpoint every CLI user hits), every merge that touches demo-relevant files should redeploy.

## Changes
- **Add `push: branches: [main]` trigger** with a `paths:` filter so doc-only and CI-only merges don't rebuild the demo unnecessarily. Filter includes: `apps/demo/**`, `packages/**`, `deploy/demo/**`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `package.json`, and the workflow file itself.
- **Add `concurrency` group** `deploy-demo` with `cancel-in-progress: false` so back-to-back merges queue cleanly instead of racing on the same Fly app.
- Existing `release: published` and `workflow_dispatch` triggers preserved.

## Test Plan
- [x] YAML parses
- [ ] First post-merge push to `apps/demo/**` or `packages/**` triggers deploy automatically
- [ ] Doc-only merges do NOT trigger deploy