### PR TITLE
chore(release): bump to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Universal UI layer for MCP servers",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/app",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Headless SDK for Burnish — navigation, sessions, streaming, and output transformation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Swagger UI for MCP servers — explore, test, and visualize any MCP server",
   "type": "module",
   "bin": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/components",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Lit web components for rendering MCP tool call results",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/example-server/package.json
+++ b/packages/example-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/example-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Example MCP server showcasing Burnish components with demo tools",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/renderer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Streaming HTML renderer and component mapper for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP orchestration and session management for Burnish",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Bumps `burnish` CLI and all published `@burnishdev/*` packages to **0.2.0**.

## Why minor, not patch
Since `0.1.1` was published (2026-04-07), main has added a **user-visible behavior change**: opt-in telemetry (#392) prompts users on first run of `npx burnish`. That is a textbook semver-minor trigger.

## Changes since 0.1.1
- **feat:** opt-in anonymous telemetry for `npx burnish` (#392)
- **fix:** enum select dropdown shows enum values (#377)
- **feat(brand):** new flame-B logo + favicons + og-image (#397)
- **docs:** HN-launch README rewrite with hero GIF, quickstart, icon comparison matrix (#384)
- **feat(site):** Navigator (formerly Copilot) waitlist link (#388)
- **test:** clean-machine smoke test for published npm package (#386)
- **ci:** auto-deploy demo on push to main (#403)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass
- [ ] Tag `v0.2.0` + GitHub release triggers `publish.yml`
- [ ] `burnish@0.2.0` lands on npmjs.com
- [ ] Smoke test against `burnish@latest` passes