### PR TITLE
fix(readme): use 4-backtick outer fence for nested bash example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ All configured servers connect at startup. Their tools are available immediately
 
 Let your users explore your server without cloning anything. Drop this into your README:
 
-```markdown
+````markdown
 [![Explore with Burnish](https://img.shields.io/badge/Explore-with%20Burnish-8B3A3A)](https://github.com/danfking/burnish)
 
 ```bash
 npx burnish -- npx @your-org/your-mcp-server
 ```
-```
+````
 
 A hosted "Explore with Burnish" shields.io badge is tracked in [#385](https://github.com/danfking/burnish/issues/385).
 


### PR DESCRIPTION
## Defect
In the "For MCP server owners" section, a triple-backtick ```markdown outer fence tried to contain a triple-backtick ```bash inner fence. Markdown parsers (including GitHub's) do not support same-length nested fences — the inner ``` prematurely closes the outer, and every section below ("Links", "Features", "Component reference", SDK integration, etc.) renders as preformatted text inside a broken code block.

Caught by visual inspection of the rendered README on main before any HN traffic landed. Shipping this before publishing registry listings.

## Fix
Bump the outer fence to 4 backticks. GitHub-flavored markdown allows fences of differing lengths, so the 4-backtick outer cleanly contains the 3-backtick inner.

## Before
```
```markdown
[![Explore with Burnish](...)](https://github.com/danfking/burnish)
```bash
npx burnish -- npx @your-org/your-mcp-server
```
```
```

## After (outer fence is now 4 backticks)
````
````markdown
[![Explore with Burnish](...)](https://github.com/danfking/burnish)
```bash
npx burnish -- npx @your-org/your-mcp-server
```
````
````