### PR TITLE
fix(server): safePath strips leading slashes (0.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Universal UI layer for MCP servers",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Headless SDK for Burnish — navigation, sessions, streaming, and output transformation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Swagger UI for MCP servers — explore, test, and visualize any MCP server",
   "type": "module",
   "bin": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lit web components for rendering MCP tool call results",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/example-server/package.json
+++ b/packages/example-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/example-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Example MCP server showcasing Burnish components with demo tools",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/renderer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Streaming HTML renderer and component mapper for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP orchestration and session management for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/guards.test.ts
+++ b/packages/server/src/guards.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect } from 'vitest';
-import { isWriteTool, authorizeToolCall, consumeAuthorization, guardToolExecution } from './guards.js';
+import { resolve } from 'node:path';
+import { isWriteTool, authorizeToolCall, consumeAuthorization, guardToolExecution, safePath } from './guards.js';
+
+describe('safePath', () => {
+    const baseDir = resolve('/tmp/burnish-assets');
+
+    it('accepts a URL-style path with a leading slash and treats it as relative to baseDir', () => {
+        // Regression: v0.2.0 shipped a safePath that called path.resolve(baseDir, '/style.css'),
+        // which on POSIX returns '/style.css' and on Windows returns the current drive root.
+        // Both fail the startsWith(baseDir) check, causing every CLI static asset to 404.
+        expect(safePath(baseDir, '/style.css')).toBe(resolve(baseDir, 'style.css'));
+        expect(safePath(baseDir, '/components/card.js')).toBe(resolve(baseDir, 'components/card.js'));
+    });
+
+    it('accepts a relative path', () => {
+        expect(safePath(baseDir, 'tokens.css')).toBe(resolve(baseDir, 'tokens.css'));
+    });
+
+    it('rejects path traversal attempts', () => {
+        expect(safePath(baseDir, '../etc/passwd')).toBe(null);
+        expect(safePath(baseDir, '/../../etc/passwd')).toBe(null);
+    });
+});
 
 describe('isWriteTool', () => {
     it('identifies write tools by name prefix', () => {

--- a/packages/server/src/guards.ts
+++ b/packages/server/src/guards.ts
@@ -10,9 +10,16 @@ const WRITE_PATTERNS = /^(create|update|delete|remove|push|write|edit|move|fork|
 /**
  * Resolve a user-supplied path against a base directory and verify
  * it does not escape outside the base (prevents path traversal).
+ *
+ * Leading slashes on userPath are stripped so it is treated as relative
+ * to baseDir — otherwise Node's path.resolve() interprets a URL-style
+ * path like "/style.css" as absolute and discards baseDir entirely,
+ * causing every static file request in the CLI to fail validation and
+ * return 404. Regression shipped in v0.2.0, fixed in v0.2.1.
  */
 export function safePath(baseDir: string, userPath: string): string | null {
-    const resolved = normalize(resolve(baseDir, userPath));
+    const relative = userPath.replace(/^[/\\]+/, '');
+    const resolved = normalize(resolve(baseDir, relative));
     const base = normalize(baseDir);
     return resolved.startsWith(base + '\\') || resolved.startsWith(base + '/') || resolved === base
         ? resolved

--- a/scripts/smoke-test.ps1
+++ b/scripts/smoke-test.ps1
@@ -91,6 +91,24 @@ try {
                 } else {
                     Fail "response body did not contain 'burnish' or '<script'"
                 }
+
+                # Static asset checks — v0.2.0 shipped with a safePath bug that
+                # made every CSS/JS request 404 while the bare '/' route still
+                # worked. Verify at least one CSS + one component JS load with
+                # 200 and a non-empty body.
+                foreach ($asset in @('/tokens.css', '/style.css', '/components/card.js')) {
+                    try {
+                        $assetResp = Invoke-WebRequest -Uri ($Url + $asset) -UseBasicParsing -TimeoutSec 15
+                        $assetLen = if ($assetResp.Content) { $assetResp.Content.Length } else { 0 }
+                        if ($assetResp.StatusCode -eq 200 -and $assetLen -gt 0) {
+                            Pass "GET $Url$asset returned 200 ($assetLen bytes)"
+                        } else {
+                            Fail "GET $Url$asset returned HTTP $($assetResp.StatusCode), $assetLen bytes"
+                        }
+                    } catch {
+                        Fail "GET $Url$asset failed: $($_.Exception.Message)"
+                    }
+                }
             } else {
                 Fail "GET $Url returned HTTP $($response.StatusCode)"
             }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -128,6 +128,21 @@ if [ "$READY" -eq 1 ]; then
         head -c 400 "$BODY_FILE" 2>/dev/null | sed 's/^/    | /'
         echo
     fi
+
+    # Static asset checks — v0.2.0 shipped with a safePath bug that made every
+    # CSS/JS request 404 while the bare '/' route still worked. HTML-only smoke
+    # checks do not catch this. We now verify that at least one CSS file, one
+    # component JS, and the tokens file all load with 200 and a non-empty body.
+    for ASSET in "/tokens.css" "/style.css" "/components/card.js"; do
+        ASSET_FILE="$TMPDIR_SMOKE/asset$(echo "$ASSET" | tr '/' '_')"
+        ASSET_CODE="$(curl -sS -o "$ASSET_FILE" -w '%{http_code}' "${URL}${ASSET}" || echo 000)"
+        ASSET_SIZE="$(wc -c < "$ASSET_FILE" 2>/dev/null || echo 0)"
+        if [ "$ASSET_CODE" = "200" ] && [ "$ASSET_SIZE" -gt 0 ]; then
+            pass "GET ${URL}${ASSET} returned 200 (${ASSET_SIZE} bytes)"
+        else
+            fail "GET ${URL}${ASSET} returned HTTP $ASSET_CODE, ${ASSET_SIZE} bytes"
+        fi
+    done
 fi
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Why this exists
`burnish@0.2.0` shipped with a `safePath()` implementation that discards `baseDir` whenever the incoming URL path starts with a slash. Every CSS, JS, and image request served by the CLI's catch-all route returned 404. The only thing that worked was `/` (served by an explicit handler), which is why both the smoke test and the HTTP boot check passed while the actual rendered UI was unstyled raw HTML.

Reported by danfking via screenshot after running `npx burnish@0.2.0` locally. Not flagged by CI because CI only curled `/`.

## Fix
```ts
// Before
const resolved = normalize(resolve(baseDir, userPath));
// After
const relative = userPath.replace(/^[/\]+/, '');
const resolved = normalize(resolve(baseDir, relative));
```

Node's `path.resolve(base, '/style.css')` returns `/style.css` on POSIX and the current drive root on Windows — both fail the `startsWith(baseDir)` check and `safePath` returns `null`, so every static asset 404s. Stripping the leading slash first makes userPath relative, which is the semantic the catch-all actually wants.

## Regression gate
The smoke test scripts (bash and PowerShell) now curl three static assets (`/tokens.css`, `/style.css`, `/components/card.js`) in addition to the HTML root. Each must return 200 with a non-empty body. An HTML-only smoke check is no longer sufficient — this class of bug is now caught on every `workflow_dispatch` or `v*` tag run.

## Test coverage
Added four `safePath` tests to `packages/server/src/guards.test.ts`:
- URL-style path with leading slash (the regression case)
- URL-style path with nested subdirectory
- Plain relative path (unchanged behavior)
- Path traversal attempts rejected (`../etc/passwd`, `/../../etc/passwd`)

Existing tests still pass.

## Release
Patch bump: 0.2.0 → 0.2.1 across `burnish` and all `@burnishdev/*` packages.

Will tag `v0.2.1` after merge to trigger `publish.yml`, then dispatch the upgraded smoke test to verify the fix on clean macOS / Ubuntu / Windows runners.

## Test Plan
- [x] `pnpm build` passes
- [x] `guards.test.ts` — 14/14 (includes 4 new `safePath` cases)
- [ ] `burnish@0.2.1` lands on npmjs.com
- [ ] Smoke test PASSes on all 3 platforms including the new static-asset checks
- [ ] Local verification: `npx burnish@0.2.1` renders with full styling