### PR TITLE
fix(cli): glob-copy public assets in bundle (0.2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Universal UI layer for MCP servers",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Headless SDK for Burnish — navigation, sessions, streaming, and output transformation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Swagger UI for MCP servers — explore, test, and visualize any MCP server",
   "type": "module",
   "bin": {

--- a/packages/cli/scripts/bundle-assets.js
+++ b/packages/cli/scripts/bundle-assets.js
@@ -11,19 +11,29 @@ mkdirSync(resolve(assets, 'components'), { recursive: true });
 mkdirSync(resolve(assets, 'app'), { recursive: true });
 mkdirSync(resolve(assets, 'renderer'), { recursive: true });
 
-// Copy demo public files
+// Copy all top-level files from apps/demo/public/ to assets/.
+//
+// Previously this was a hand-maintained allowlist, which drifted from reality
+// whenever a new .js file was added: 0.2.1 shipped without template-learning.js,
+// perf-panel.js, and ambient-suggestions.js, so the landing page 404'd those
+// imports and the MCP server buttons failed to render. Glob-copy everything
+// top-level (by extension allowlist, not filename allowlist) so adding a new
+// asset to the demo app just works, and remove this class of bug permanently.
+//
+// Subdirectories under public/ are intentionally NOT recursed — compiled
+// packages (components/, app/, renderer/) are copied separately below.
+// index.html is also handled explicitly at the bottom of this script.
 const publicDir = resolve(root, 'apps/demo/public');
-const filesToCopy = [
-    'app.js', 'shared.js', 'view-renderers.js', 'contextual-actions.js',
-    'deterministic-ui.js', 'style.css', 'tokens.css',
-];
-for (const f of filesToCopy) {
-    const src = resolve(publicDir, f);
-    if (existsSync(src)) {
-        cpSync(src, resolve(assets, f));
-    } else {
-        console.warn(`[burnish] Warning: ${f} not found in demo public/`);
-    }
+const PUBLIC_EXT_ALLOWLIST = new Set([
+    '.js', '.mjs', '.css', '.html', '.json', '.svg',
+    '.png', '.ico', '.webmanifest',
+]);
+for (const entry of readdirSync(publicDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (entry.name === 'index.html') continue; // written explicitly at bottom
+    const ext = extname(entry.name).toLowerCase();
+    if (!PUBLIC_EXT_ALLOWLIST.has(ext)) continue;
+    cpSync(resolve(publicDir, entry.name), resolve(assets, entry.name));
 }
 
 /**
@@ -61,18 +71,8 @@ if (existsSync(componentTokens)) {
     cpSync(componentTokens, resolve(assets, 'components/tokens.css'));
 }
 
-// Copy favicon, logo, and manifest files
-const assetFiles = [
-    'favicon.ico', 'favicon-16x16.png', 'favicon-32x32.png',
-    'apple-touch-icon.png', 'android-chrome-192x192.png', 'android-chrome-512x512.png',
-    'logo.png', 'site.webmanifest',
-];
-for (const f of assetFiles) {
-    const src = resolve(publicDir, f);
-    if (existsSync(src)) {
-        cpSync(src, resolve(assets, f));
-    }
-}
+// Favicons, logos, and manifests are now handled by the glob-copy above
+// (the PUBLIC_EXT_ALLOWLIST includes .ico, .png, .svg, .webmanifest).
 
 // Copy index.html from demo
 // The import map already uses /app/, /renderer/, /components/ paths which match our layout

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Lit web components for rendering MCP tool call results",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/example-server/package.json
+++ b/packages/example-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/example-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Example MCP server showcasing Burnish components with demo tools",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/renderer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Streaming HTML renderer and component mapper for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP orchestration and session management for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -143,6 +143,37 @@ if [ "$READY" -eq 1 ]; then
             fail "GET ${URL}${ASSET} returned HTTP $ASSET_CODE, ${ASSET_SIZE} bytes"
         fi
     done
+
+    # Dynamic-import check — v0.2.1 shipped with a hand-maintained bundle
+    # allowlist that forgot template-learning.js, perf-panel.js, and
+    # ambient-suggestions.js, so the landing page 404'd those imports at
+    # runtime and MCP server buttons never rendered. Parse /app.js for its
+    # relative imports and verify each one loads.
+    APP_JS="$TMPDIR_SMOKE/app.js"
+    if curl -sSf -o "$APP_JS" "${URL}/app.js" 2>/dev/null; then
+        IMPORT_LIST="$(grep -oE "['\"][./][^'\"]*\.(js|mjs|css)['\"]" "$APP_JS" 2>/dev/null \
+            | tr -d "'\"" | sort -u)"
+        if [ -n "$IMPORT_LIST" ]; then
+            while IFS= read -r IMPORT; do
+                [ -z "$IMPORT" ] && continue
+                case "$IMPORT" in
+                    /*) URL_PATH="$IMPORT" ;;
+                    ./*) URL_PATH="/${IMPORT#./}" ;;
+                    *)  URL_PATH="/$IMPORT" ;;
+                esac
+                IMP_CODE="$(curl -sS -o /dev/null -w '%{http_code}' "${URL}${URL_PATH}" || echo 000)"
+                if [ "$IMP_CODE" = "200" ]; then
+                    pass "app.js import ${URL_PATH} -> 200"
+                else
+                    fail "app.js import ${URL_PATH} -> HTTP $IMP_CODE (bundle drift?)"
+                fi
+            done <<< "$IMPORT_LIST"
+        else
+            pass "app.js has no relative imports to verify"
+        fi
+    else
+        fail "could not fetch ${URL}/app.js for dynamic-import verification"
+    fi
 fi
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Why
v0.2.1 fixed the `safePath` bug, but the CLI UI still had broken imports. `apps/demo/public/` contains 8 top-level JS files; `bundle-assets.js` only copied 5 of them via a hand-maintained allowlist. The missing three — `template-learning.js`, `perf-panel.js`, `ambient-suggestions.js` — are imported by `app.js` at runtime, so the landing page 404'd them and the MCP server buttons never populated.

Reported by danfking with a screenshot showing two console 404s from app.js:30 and app.js:60.

## Fix
Replace the hand-maintained allowlist with a glob-copy that iterates `apps/demo/public/` top-level files and copies every file whose extension is in `PUBLIC_EXT_ALLOWLIST` (`.js`, `.mjs`, `.css`, `.html`, `.json`, `.svg`, `.png`, `.ico`, `.webmanifest`). Adding a new demo asset no longer requires touching the bundle script. The old `assetFiles` list for favicons/logos also collapses into the same glob.

## Regression gate
`smoke-test.sh` now downloads `/app.js` and greps for string literals that look like relative JS/CSS imports. Each import is curled and must return 200. If a future bundle drops a referenced file, the smoke test fails instead of shipping silently.

## Verified locally
```
packages/cli/assets/ambient-suggestions.js   ← new
packages/cli/assets/app.js
packages/cli/assets/contextual-actions.js
packages/cli/assets/deterministic-ui.js
packages/cli/assets/perf-panel.js            ← new
packages/cli/assets/shared.js
packages/cli/assets/template-learning.js     ← new
packages/cli/assets/view-renderers.js
```

## Release
Patch: 0.2.1 → 0.2.2 across all published packages.

## Test Plan
- [x] `pnpm build` passes
- [x] `packages/cli/assets/` contains all 8 expected JS files
- [ ] `burnish@0.2.2` lands on npmjs.com
- [ ] Smoke test passes with the new app.js import verification
- [ ] Local: `npx burnish@0.2.2` renders MCP server buttons with names