### PR TITLE
docs(readme): use @burnishdev/example-server as the primary demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@
 ## Quickstart
 
 ```bash
-npx burnish -- npx @modelcontextprotocol/server-filesystem /tmp
+npx burnish -- npx -y @burnishdev/example-server
 ```
 
-That's it. Burnish spawns the MCP server, reads its tool list, opens your browser, and renders every tool as an interactive form. Click one, fill it in, see the result as cards, tables, or charts — not raw JSON.
+That's it. Burnish spawns the example MCP server, reads its tool list, opens your browser, and renders every tool as an interactive form. The example server ships with a dozen tools — creating bug reports, listing team members, searching records — so you can click through, fill in forms, and see results rendered as cards, tables, and charts without writing a line of your own MCP code.
+
+Want to try it against a different server? Point `burnish` at any stdio or SSE MCP server — see [What you can point it at](#what-you-can-point-it-at) below.
 
 <p align="center">
   <picture>
@@ -62,12 +64,15 @@ Try the hosted demo: **[burnish-demo.fly.dev](https://burnish-demo.fly.dev)**
 ## What you can point it at
 
 ```bash
-# A stdio server (most common)
-npx burnish -- npx @modelcontextprotocol/server-filesystem /tmp
+# The Burnish example server — richest default demo
+npx burnish -- npx -y @burnishdev/example-server
+
+# Any published stdio MCP server
+npx burnish -- npx -y @modelcontextprotocol/server-filesystem /tmp
 
 # GitHub (needs a PAT)
 GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... \
-  npx burnish -- npx @modelcontextprotocol/server-github
+  npx burnish -- npx -y @modelcontextprotocol/server-github
 
 # An SSE / HTTP MCP server
 npx burnish --sse https://your-mcp-server.example.com/sse
@@ -209,6 +214,10 @@ Configure in `apps/demo/mcp-servers.json` when running from source, or pass `--c
 ```json
 {
   "mcpServers": {
+    "example": {
+      "command": "npx",
+      "args": ["-y", "@burnishdev/example-server"]
+    },
     "filesystem": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]


### PR DESCRIPTION
## Why
`@modelcontextprotocol/server-filesystem` was the default quickstart demo, but it is a weak showcase of what Burnish actually does — 14 tools that are all file ops, limited schema variety, nothing that exercises enums, status visualizations, or the rich card/table rendering.

`@burnishdev/example-server` (which we already publish on every release, latest is 0.2.2) is much better: 12 schema-rich tools including `create-bug-report` (with the severity enum dropdown that showcases the #377 fix), team listings, search records, etc. It is the exact server used in the demo GIF, so the README hero, the GIF, and the CLI quickstart all line up visually.

Swapping just the primary example, not removing filesystem as an alternative.

## Changes
- **Quickstart block** — swap the hero command from `npx burnish -- npx @modelcontextprotocol/server-filesystem /tmp` to `npx burnish -- npx -y @burnishdev/example-server`, and expand the follow-up prose to highlight what the example server ships.
- **"What you can point it at" section** — lead with `@burnishdev/example-server` as the richest default demo, keep filesystem + github + SSE + config examples below.
- **`mcp-servers.json` sample** — add an `example` entry above `filesystem` so users see a one-line path to the demo server.
- Doc-only change, no code touched.

## Post-launch follow-up
Hosting `@burnishdev/example-server` over SSE on `burnish-demo.fly.dev` would let users try it with zero installs via `npx burnish --sse https://burnish-demo.fly.dev/mcp/example/sse`. That requires an MCP stdio→SSE bridge + lifecycle management on the Fly app and is a separate launch-week polish item (filing an issue).

## Test Plan
- [x] README renders on github.com (no code fences broken)
- [x] `@burnishdev/example-server` is live on npm (`npm dist-tags get @burnishdev/example-server` -> latest: 0.2.2)
- [ ] Local: `npx burnish -- npx -y @burnishdev/example-server` shows the 12 tools list with the `create-bug-report` form