### PR TITLE
feat(server): surface MCP server instructions on landing page (#411)

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1418,13 +1418,23 @@ async function loadDynamicSuggestions(container) {
             if (servers.length === 0) {
                 serverBtns.innerHTML = '<span class="burnish-no-servers">No servers connected</span>';
             } else {
-                serverBtns.innerHTML = servers.map(s => `
-                    <button class="burnish-suggestion burnish-suggestion-server" data-label="${escapeAttr(s.name)}">
+                serverBtns.innerHTML = servers.map(s => {
+                    const hasInstructions = typeof s.instructions === 'string' && s.instructions.trim().length > 0;
+                    const descText = hasInstructions
+                        ? s.instructions.trim()
+                        : `${s.toolCount} tools — no description provided`;
+                    const toolCountLine = hasInstructions
+                        ? `<span class="burnish-suggestion-sub">${s.toolCount} tools</span>`
+                        : '';
+                    return `
+                    <button class="burnish-suggestion burnish-suggestion-server" data-label="${escapeAttr(s.name)}" title="${escapeAttr(descText)}">
                         <span class="burnish-server-status ${s.status === 'connected' ? 'connected' : 'disconnected'}"></span>
                         ${escapeHtml(s.name)}
-                        <span class="burnish-suggestion-sub">${s.toolCount} tools</span>
+                        ${toolCountLine}
+                        <span class="burnish-server-card-description${hasInstructions ? '' : ' burnish-server-card-description-empty'}">${escapeHtml(descText)}</span>
                     </button>
-                `).join('');
+                `;
+                }).join('');
             }
         }
 

--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -860,17 +860,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        // Deterministic server button — render tool listing
-        if (btn.classList.contains('burnish-suggestion-server')) {
-            const serverName = btn.dataset.label;
-            const cachedServers = getCachedServers();
-            const serverData = cachedServers?.find(s => s.name === serverName);
-            if (serverData && serverData.tools.length > 0) {
-                renderDeterministicToolListing(serverName, serverData.tools);
-                return;
-            }
-        }
-
         // For any other suggestion, show available servers
         if (btn.dataset.prompt) {
             const cachedServers = getCachedServers();
@@ -878,6 +867,19 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const first = cachedServers[0];
                 renderDeterministicToolListing(first.name, first.tools);
             }
+        }
+    });
+
+    // ── Server card drill-down (landing page) ──
+    document.addEventListener('burnish-card-action', (e) => {
+        const card = e.target;
+        if (!card || !card.closest('#server-buttons')) return;
+        const { itemId } = e.detail || {};
+        if (!itemId) return;
+        const cachedServers = getCachedServers();
+        const serverData = cachedServers?.find(s => s.name === itemId);
+        if (serverData && serverData.tools.length > 0) {
+            renderDeterministicToolListing(itemId, serverData.tools);
         }
     });
 
@@ -1420,19 +1422,19 @@ async function loadDynamicSuggestions(container) {
             } else {
                 serverBtns.innerHTML = servers.map(s => {
                     const hasInstructions = typeof s.instructions === 'string' && s.instructions.trim().length > 0;
-                    const descText = hasInstructions
+                    const bodyText = hasInstructions
                         ? s.instructions.trim()
-                        : `${s.toolCount} tools — no description provided`;
-                    const toolCountLine = hasInstructions
-                        ? `<span class="burnish-suggestion-sub">${s.toolCount} tools</span>`
-                        : '';
+                        : `No description provided`;
+                    const statusVal = s.status === 'connected' ? 'success' : 'error';
+                    const statusLabel = `${s.toolCount} tools`;
                     return `
-                    <button class="burnish-suggestion burnish-suggestion-server" data-label="${escapeAttr(s.name)}" title="${escapeAttr(descText)}">
-                        <span class="burnish-server-status ${s.status === 'connected' ? 'connected' : 'disconnected'}"></span>
-                        ${escapeHtml(s.name)}
-                        ${toolCountLine}
-                        <span class="burnish-server-card-description${hasInstructions ? '' : ' burnish-server-card-description-empty'}">${escapeHtml(descText)}</span>
-                    </button>
+                    <burnish-card
+                        title="${escapeAttr(s.name)}"
+                        status="${escapeAttr(statusVal)}"
+                        status-label="${escapeAttr(statusLabel)}"
+                        body="${escapeAttr(bodyText)}"
+                        item-id="${escapeAttr(s.name)}"
+                    ></burnish-card>
                 `;
                 }).join('');
             }

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -302,6 +302,27 @@ body {
     font-weight: 400;
     margin-top: 2px;
 }
+.burnish-suggestion-server { max-width: 260px; }
+.burnish-server-card-description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    width: 100%;
+    margin-top: 4px;
+    font-size: 11px;
+    line-height: 1.35;
+    font-weight: 400;
+    color: var(--burnish-text-muted, #9C8F8F);
+    text-transform: none;
+    white-space: normal;
+    text-align: center;
+}
+.burnish-server-card-description-empty {
+    font-style: italic;
+    opacity: 0.75;
+}
 .burnish-suggestion-skeleton-pill {
     width: 140px;
     height: 40px;

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -250,13 +250,17 @@ body {
     color: var(--burnish-text);
 }
 .burnish-server-buttons {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 12px;
     margin-bottom: 16px;
     max-width: 720px;
     margin-left: auto;
     margin-right: auto;
+}
+.burnish-server-buttons > * {
+    flex: 0 1 340px;
 }
 .burnish-server-buttons:empty { display: none; }
 .burnish-tool-shortcuts {
@@ -1167,7 +1171,7 @@ body {
     .burnish-theme-toggle span { display: none; }
     .burnish-empty-state { padding: 40px 16px 40px; }
     .burnish-empty-state h2 { font-size: 22px; }
-    .burnish-server-buttons { grid-template-columns: 1fr; }
+    .burnish-server-buttons > * { flex: 1 1 100%; }
     .burnish-tool-shortcuts { flex-direction: column; align-items: center; }
     .burnish-starter-prompts { flex-direction: column; align-items: center; }
 }

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -250,33 +250,15 @@ body {
     color: var(--burnish-text);
 }
 .burnish-server-buttons {
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 12px;
     margin-bottom: 16px;
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
 }
 .burnish-server-buttons:empty { display: none; }
-.burnish-suggestion-server {
-    font-weight: 600;
-    font-size: 13px;
-    padding: 10px 20px;
-    text-transform: capitalize;
-    display: inline-flex;
-    align-items: center;
-    flex-wrap: wrap;
-    justify-content: center;
-}
-.burnish-server-status {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    margin-right: 6px;
-    flex-shrink: 0;
-}
-.burnish-server-status.connected { background: var(--burnish-success, #22c55e); }
-.burnish-server-status.disconnected { background: var(--burnish-error, #ef4444); }
 .burnish-tool-shortcuts {
     display: flex;
     gap: 8px;
@@ -294,35 +276,6 @@ body {
     padding-top: 12px;
 }
 .burnish-starter-prompts:empty { display: none; padding: 0; }
-.burnish-suggestion-sub {
-    display: block;
-    width: 100%;
-    font-size: 11px;
-    color: var(--burnish-text-muted, #9C8F8F);
-    font-weight: 400;
-    margin-top: 2px;
-}
-.burnish-suggestion-server { max-width: 260px; }
-.burnish-server-card-description {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    overflow: hidden;
-    width: 100%;
-    margin-top: 4px;
-    font-size: 11px;
-    line-height: 1.35;
-    font-weight: 400;
-    color: var(--burnish-text-muted, #9C8F8F);
-    text-transform: none;
-    white-space: normal;
-    text-align: center;
-}
-.burnish-server-card-description-empty {
-    font-style: italic;
-    opacity: 0.75;
-}
 .burnish-suggestion-skeleton-pill {
     width: 140px;
     height: 40px;
@@ -1214,7 +1167,7 @@ body {
     .burnish-theme-toggle span { display: none; }
     .burnish-empty-state { padding: 40px 16px 40px; }
     .burnish-empty-state h2 { font-size: 22px; }
-    .burnish-server-buttons { flex-direction: column; align-items: center; }
+    .burnish-server-buttons { grid-template-columns: 1fr; }
     .burnish-tool-shortcuts { flex-direction: column; align-items: center; }
     .burnish-starter-prompts { flex-direction: column; align-items: center; }
 }

--- a/packages/example-server/src/index.ts
+++ b/packages/example-server/src/index.ts
@@ -4,10 +4,16 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
-const server = new McpServer({
-  name: "burnish-example-server",
-  version: "0.1.0",
-});
+const server = new McpServer(
+  {
+    name: "burnish-example-server",
+    version: "0.1.0",
+  },
+  {
+    instructions:
+      "A demo MCP server for the Burnish Explorer. Showcases auto-generated forms, rich result rendering, and connected drill-down navigation with a fictional project-management dataset.",
+  }
+);
 
 // --- Tool: get-project-info ---
 server.tool(

--- a/packages/server/src/mcp-hub.ts
+++ b/packages/server/src/mcp-hub.ts
@@ -60,6 +60,7 @@ interface ConnectedServer {
     status: 'connected' | 'disconnected';
     lastError?: string;
     lastErrorTime?: number;
+    instructions?: string;
 }
 
 export class McpHub {
@@ -136,6 +137,7 @@ export class McpHub {
             serverName: name,
         }));
 
+        const instructions = client.getInstructions();
         this.servers.push({
             name,
             client,
@@ -143,6 +145,7 @@ export class McpHub {
             tools,
             config: {},
             status: 'connected',
+            instructions,
         });
     }
 
@@ -188,7 +191,8 @@ export class McpHub {
             serverName: name,
         }));
 
-        this.servers.push({ name, client, transport, tools, config, status: 'connected' });
+        const instructions = client.getInstructions();
+        this.servers.push({ name, client, transport, tools, config, status: 'connected', instructions });
     }
 
     /**
@@ -251,12 +255,13 @@ export class McpHub {
     /**
      * Get connected server info.
      */
-    getServerInfo(): Array<{ name: string; toolCount: number; status: string; lastError?: string; tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }> }> {
+    getServerInfo(): Array<{ name: string; toolCount: number; status: string; lastError?: string; instructions?: string; tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }> }> {
         const serverInfo = this.servers.map(s => ({
             name: s.name,
             toolCount: s.tools.length,
             status: s.status,
             lastError: s.lastError,
+            instructions: s.instructions,
             tools: s.tools.map(t => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })),
         }));
 
@@ -266,6 +271,7 @@ export class McpHub {
                 toolCount: this.cliTools.length,
                 status: 'connected' as const,
                 lastError: undefined,
+                instructions: undefined,
                 tools: this.cliTools.map(ct => ({
                     name: ct.toolDef.name,
                     description: ct.toolDef.description,

--- a/tests/visual/verify-411.mjs
+++ b/tests/visual/verify-411.mjs
@@ -1,0 +1,24 @@
+import { chromium } from '@playwright/test';
+
+const URL = process.env.BURNISH_URL || 'http://localhost:3411';
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await ctx.newPage();
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('.burnish-suggestion-server', { timeout: 10000 });
+await page.waitForFunction(() => {
+    const el = document.querySelector('.burnish-server-card-description');
+    return el && el.textContent && el.textContent.trim().length > 0;
+}, { timeout: 5000 });
+
+for (const theme of ['light', 'dark']) {
+    await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);
+    await page.waitForTimeout(150);
+    const out = `tests/visual/screenshots/verify-411-${theme}.png`;
+    await page.screenshot({ path: out, fullPage: false });
+    console.log('saved', out);
+}
+
+await browser.close();


### PR DESCRIPTION
## Summary
Closes #411. Surfaces the MCP `instructions` field so users immediately understand what each connected MCP server is for.

## Changes
**1. `@burnishdev/server` (`packages/server/src/mcp-hub.ts`)**
- Capture `client.getInstructions()` after connect for both `connectServer()` and `registerClient()`.
- Stash on `ConnectedServer` and expose `instructions?: string` from `getServerInfo()`.

**2. `@burnishdev/example-server` (`packages/example-server/src/index.ts`)**
- Pass `instructions` via the SDK's second `ServerOptions` argument:
  > "A demo MCP server for the Burnish Explorer. Showcases auto-generated forms, rich result rendering, and connected drill-down navigation with a fictional project-management dataset."

**3. `apps/demo/public` (landing page)**
- Server display upgraded from pills to `<burnish-card>` web components. Each card shows:
  - Server name as title
  - Green status bar for connected servers
  - Tool count badge (e.g. "12 TOOLS")
  - Full instructions text in the card body (no truncation)
  - "Explore →" action link
- Cards are centered horizontally using flexbox (`justify-content: center`) with `max-width: 720px`.
- Single cards center on the page; multiple cards wrap naturally.

## Verification
**Light mode:**
![verify-411-centered-light](https://raw.githubusercontent.com/danfking/burnish/fedd171/verify-411-centered-light.png)

**Dark mode:**
![verify-411-centered-dark](https://raw.githubusercontent.com/danfking/burnish/fedd171/verify-411-centered-dark.png)

## Test Plan
- [x] `pnpm build` passes
- [x] CI tests pass
- [x] Visual verification confirms centered card rendering in both themes