### PR TITLE
fix(test): update loading-states test for burnish-card server display

### DIFF
--- a/tests/loading-states.spec.ts
+++ b/tests/loading-states.spec.ts
@@ -3,13 +3,16 @@ import { test, expect } from '@playwright/test';
 test.describe('Loading states', () => {
     test('loading spinner appears during tool execution', async ({ page }) => {
         await page.goto('/');
-        // Click a server button
-        const serverBtn = page.locator('#server-buttons button').first();
-        if (await serverBtn.count() === 0) {
+        // Click a server card's Explore action
+        const serverCard = page.locator('#server-buttons burnish-card').first();
+        if (await serverCard.count() === 0) {
             test.skip();
             return;
         }
-        await serverBtn.click();
+        await serverCard.evaluate(el => {
+            const btn = el.shadowRoot?.querySelector('.explore-btn, button');
+            if (btn) (btn as HTMLElement).click();
+        });
         await page.waitForTimeout(1000);
 
         // Find a tool card and click it


### PR DESCRIPTION
## Summary
Fixes broken CI test after #413 changed server display from `<button>` to `<burnish-card>`.

## Changes
`tests/loading-states.spec.ts`: Update `#server-buttons button` selector to `#server-buttons burnish-card` and click through shadow DOM Explore action, matching the new card-based server display.

[skip-screenshot]

## Test Plan
- [x] `pnpm build` passes
- [ ] CI test passes (this PR fixes it)