### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "description": "Universal UI layer for MCP servers",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/app",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Headless SDK for Burnish — navigation, sessions, streaming, and output transformation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnish",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Swagger UI for MCP servers — explore, test, and visualize any MCP server",
   "type": "module",
   "bin": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/components",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Lit web components for rendering MCP tool call results",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/example-server/package.json
+++ b/packages/example-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/example-server",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Example MCP server showcasing Burnish components with demo tools",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/renderer",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Streaming HTML renderer and component mapper for Burnish",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burnishdev/server",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "MCP orchestration and session management for Burnish",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Bumps all workspace package versions from 0.2.2 to 0.3.0.

Includes all features and fixes merged since 0.2.2:
- feat(server): server instructions with cards (#413)
- feat(example-server): connected graph domain with deep drill-down (#420)
- fix(ui): dark theme default + delete button (#421)
- fix(ui): card max-width + focus toggle (#419)
- fix(test): loading-states test for burnish-card (#422)

## Changes
- Updated `version` field in all 7 `package.json` files (root + 6 packages)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass