### PR TITLE
fix(components): widen empty-state container for card grid wrap

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -225,7 +225,7 @@ body {
     text-align: center;
     padding: 40px 20px;
     color: var(--burnish-text-secondary);
-    max-width: 600px;
+    max-width: 760px;
     margin: 0 auto;
 }
 .burnish-empty-icon { margin-bottom: 16px; }

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -17,9 +17,8 @@ export class BurnishCard extends LitElement {
     static styles = css`
         :host {
             display: block;
-            width: 340px;
             max-width: 100%;
-            flex: 1 1 340px;
+            flex: 0 1 340px;
             min-width: 0;
             box-sizing: border-box;
             overflow: visible;


### PR DESCRIPTION
## Summary
Follow-up to #413. Server cards on the landing page were stacking vertically instead of wrapping side-by-side.

## Root Cause
`.burnish-empty-state` had `max-width: 600px`. After 40px padding, only 560px remained — too narrow for two 340px cards + 12px gap (692px needed).

## Fix
- `apps/demo/public/style.css`: increased `.burnish-empty-state` `max-width` from `600px` to `760px` (gives 720px usable, matching `.burnish-server-buttons max-width`)
- `packages/components/src/card.ts`: removed hardcoded `width: 340px` from `:host`, changed flex from `1 1 340px` to `0 1 340px` so cards don't force full-width

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass
- [ ] Cards wrap side-by-side at desktop width, stack on mobile