### PR TITLE
fix(components): add ellipsis truncation to card footer labels

### DIFF
--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -55,6 +55,8 @@ export class BurnishCard extends LitElement {
             opacity: 0.7;
             transition: opacity var(--burnish-transition-fast);
             pointer-events: none;
+            min-width: 0;
+            overflow: hidden;
         }
         .source-badge span {
             display: inline-block;
@@ -62,6 +64,11 @@ export class BurnishCard extends LitElement {
             border: 1px solid var(--burnish-border-light, #F0EAEA);
             border-radius: 3px;
             padding: 1px 6px;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            box-sizing: border-box;
         }
         .card:hover .source-badge { opacity: 1; }
         .card {
@@ -152,6 +159,9 @@ export class BurnishCard extends LitElement {
             font-size: var(--burnish-font-size-sm, 12px); color: var(--burnish-link, #7C3030);
             opacity: 0.6; transition: opacity var(--burnish-transition-fast);
             cursor: pointer;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
         .card-action:hover { background: rgba(139, 58, 58, 0.04); }
         .card:hover .card-action { opacity: 1; }


### PR DESCRIPTION
## Summary
Fixes #346

## Root Cause
Card footer labels (source badge) and action elements on mobile viewports (375px) were cut off without showing an ellipsis indicator.

## Fix / Changes
- Added `max-width: 100%`, `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, and `box-sizing: border-box` to `.source-badge span` so long source labels truncate with ellipsis
- Added `min-width: 0` and `overflow: hidden` to `.source-badge` container for proper flex constraints
- Added `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap` to `.card-action` for consistent truncation

## Verification
**Light mode (375px — with long source label):**
![verify-346-light-v2](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-346-light-v2.png)
**Dark mode (375px — with long source label):**
![verify-346-dark-v2](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-346-dark-v2.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification screenshot confirms fix