### PR TITLE
fix(demo): update timestamps periodically and reorder duration

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -389,7 +389,7 @@ function createNodeEl(node) {
         <div class="burnish-node-header" role="button" tabindex="0">
             <span class="burnish-node-chevron">\u25bc</span>
             <span class="burnish-node-prompt">${escapeHtml(node.promptDisplay || node.prompt)}</span>
-            <span class="burnish-node-time">${formatTimeAgo(node.timestamp)}</span>
+            <span class="burnish-node-time" data-timestamp="${node.timestamp}">${formatTimeAgo(node.timestamp)}</span>
             ${node._executionMode === 'deterministic' ? `<span class="burnish-exec-badge burnish-exec-badge--direct" title="No LLM — direct tool execution">Direct</span>` : ''}
             ${statsTooltip ? `<button class="burnish-node-info" title="View details">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>
@@ -769,6 +769,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     document.getElementById('btn-perf-toggle')?.addEventListener('click', () => togglePerfPanel());
+
+    // ── Periodic timestamp refresh ──
+    setInterval(() => {
+        document.querySelectorAll('.burnish-node-time[data-timestamp]').forEach(el => {
+            const ts = parseInt(el.dataset.timestamp, 10);
+            if (ts) el.textContent = formatTimeAgo(ts);
+        });
+    }, 30_000);
 
     document.getElementById('btn-dashboard-toggle')?.addEventListener('click', () => {
         dashboardMode = !dashboardMode;
@@ -1254,6 +1262,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             const resultHtml = buildResultHtml(data.result, displayLabel, toolId, undefined, data.isError);
             recordToolPerf({ toolName: toolId, latencyMs: data.durationMs || 0, responseHtml: resultHtml });
             refreshPerfPanel();
+            // Show timing badge next to timestamp
+            if (data.durationMs != null) {
+                const timeEl = document.querySelector(`[data-node-id="${nodeId}"] .burnish-node-time`);
+                if (timeEl) {
+                    const timingEl = document.createElement('span');
+                    timingEl.className = 'burnish-timing';
+                    timingEl.textContent = data.durationMs + 'ms';
+                    timeEl.after(timingEl);
+                }
+            }
             node.response = resultHtml;
             const contentEl = document.querySelector(`[data-node-id="${nodeId}"] .burnish-node-content`);
             if (contentEl) {

--- a/apps/demo/public/deterministic-ui.js
+++ b/apps/demo/public/deterministic-ui.js
@@ -225,13 +225,13 @@ export async function executeToolDirect(toolName, args, label) {
             responseHtml: resultHtml,
         });
         refreshPerfPanel();
-        // Display execution timing badge
+        // Display execution timing badge next to timestamp
         if (data.durationMs != null && node) {
             const timingEl = document.createElement('span');
             timingEl.className = 'burnish-timing';
             timingEl.textContent = data.durationMs + 'ms';
-            const headerEl = document.querySelector('[data-node-id="' + node.id + '"] .burnish-node-header');
-            if (headerEl) headerEl.appendChild(timingEl);
+            const timeEl = document.querySelector('[data-node-id="' + node.id + '"] .burnish-node-time');
+            if (timeEl) timeEl.after(timingEl);
         }
         // Record successful execution in prompt library
         if (_sessionHelpers?.promptLibrary && toolName) {


### PR DESCRIPTION
## Summary
Fixes #370

## Root Cause
Timestamps in node headers were computed once at render time via `formatTimeAgo()` and the result was baked into static HTML. They never updated, so every node permanently showed "just now". Additionally, the duration badge was appended to the end of the header (after action buttons) instead of next to the timestamp.

## Fix / Changes
- Added `data-timestamp` attribute to timestamp elements so they can be found and updated
- Added a 30-second `setInterval` that re-renders all visible timestamps with fresh relative times
- Changed the duration badge insertion from `headerEl.appendChild()` to `timeEl.after()` so it appears immediately after the timestamp, grouping temporal info together
- Added duration badge insertion to the form-submit execution path in `app.js` for consistency

## Verification
Header layout now shows: `[prompt] [5m ago] [3ms] [Direct] [actions]` — duration badge next to timestamp, and timestamp updates over time.

**Light mode (header crop):**
![verify-370-header-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-370-header-light-final.png)
**Dark mode (header crop):**
![verify-370-header-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-370-header-dark-final.png)
**Light mode (full page):**
![verify-370-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-370-light-final.png)
**Dark mode (full page):**
![verify-370-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-370-dark-final.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification confirms duration badge placed next to timestamp
- [x] `data-timestamp` attribute present for periodic refresh