### PR TITLE
fix(demo): add opaque background to sticky filter bar

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1341,8 +1341,8 @@ body {
     content: '';
     position: absolute;
     bottom: 100%;
-    left: -24px;
-    right: -24px;
+    left: 0;
+    right: 0;
     height: 200px;
     background: inherit;
 }

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1337,6 +1337,15 @@ body {
     padding: 8px 0 12px;
     background: var(--burnish-surface, #fff);
 }
+.burnish-tool-filter-container::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: -24px;
+    right: -24px;
+    height: 200px;
+    background: inherit;
+}
 .burnish-tool-filter {
     width: 100%;
     padding: 10px 12px 10px 36px;

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1335,7 +1335,7 @@ body {
     top: 0;
     z-index: 10;
     padding: 8px 0 12px;
-    background: inherit;
+    background: var(--burnish-surface, #fff);
 }
 .burnish-tool-filter {
     width: 100%;


### PR DESCRIPTION
## Summary
Fixes #428

## Root Cause
The sticky filter bar in the tool list had `background: inherit`, which resolved to transparent. This allowed scrolling tool cards to show through the filter bar. Additionally, the `.burnish-content` container has `padding: 24px`, creating a gap between the app header and the sticky filter where content was also visible during scrolling.

## Fix
1. Set an explicit opaque background on the filter bar: `background: var(--burnish-surface, #fff)`
2. Added a `::before` pseudo-element on the filter container that extends upward to cover the padding gap, preventing any content from showing between the header and filter bar

## Verification
**Light mode:**
![verify-428-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/screenshots/verify-428-light.png)

**Dark mode:**
![verify-428-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/screenshots/verify-428-dark.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass
- [x] Visual verification: no content visible through filter bar or gap above it in either theme