### PR TITLE
chore: pre-launch QA fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/danfking/burnish.git
 cd burnish
 pnpm install
 pnpm build
-pnpm dev:nomodel  # Start Explorer mode (no LLM needed)
+pnpm dev              # Start Explorer mode (no LLM needed)
 ```
 
 Open http://localhost:3000 to see the app.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ npx burnish export -- npx @your-org/your-server > schema.json
 <script type="module"
   src="https://cdn.jsdelivr.net/npm/@burnishdev/components/dist/index.js"></script>
 <link rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@burnishdev/components/dist/tokens.css" />
+  href="https://cdn.jsdelivr.net/npm/@burnishdev/components/src/tokens.css" />
 
 <burnish-card
   title="API Gateway"

--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -240,7 +240,7 @@ app.get('/api/health', (c) => {
         status: 'ok',
         servers: serverInfo.length,
         uptime: Math.floor((Date.now() - startedAt) / 1000),
-        version: '0.1.1',
+        version: '0.3.0',
     });
 });
 

--- a/deploy/demo/fly.toml
+++ b/deploy/demo/fly.toml
@@ -14,7 +14,7 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [http_service.concurrency]
     type = "requests"

--- a/examples/cdn-components.html
+++ b/examples/cdn-components.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Burnish Components — CDN Demo</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@burnishdev/components@0.1.1/dist/index.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@burnishdev/components@0.1.1/src/tokens.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@burnishdev/components@0.3.0/dist/index.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@burnishdev/components@0.3.0/src/tokens.css" />
   <style>
     body {
       font-family: system-ui, -apple-system, sans-serif;

--- a/examples/middleware-sdk/package.json
+++ b/examples/middleware-sdk/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "description": "Verify @burnishdev/server McpHub can be imported and instantiated",
   "dependencies": {
-    "@burnishdev/server": "0.1.1"
+    "@burnishdev/server": "0.3.0"
   }
 }

--- a/examples/npm-import/package.json
+++ b/examples/npm-import/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Verify @burnishdev/components and @burnishdev/renderer can be imported via npm",
   "dependencies": {
-    "@burnishdev/components": "0.1.1",
-    "@burnishdev/renderer": "0.1.1"
+    "@burnishdev/components": "0.3.0",
+    "@burnishdev/renderer": "0.3.0"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #439, fixes #440, fixes #441, fixes #443, fixes #445

Pre-launch QA testing found 7 issues across documentation, examples, and deployment config. This PR fixes the 5 that are code changes (2 remaining are docs-only future work: #442 compression, #444 output format guide).

## Changes

1. **README**: Fix broken `tokens.css` CDN path (`dist/` → `src/`) — was returning 404
2. **Examples**: Update 3 files from stale `v0.1.1` to `v0.3.0`:
   - `examples/cdn-components.html` (script + link tags)
   - `examples/npm-import/package.json` (components + renderer deps)
   - `examples/middleware-sdk/package.json` (server dep)
3. **CONTRIBUTING.md**: Fix `pnpm dev:nomodel` → `pnpm dev` (script doesn't exist)
4. **fly.toml**: Set `min_machines_running = 1` to avoid cold start during HN launch
5. **Demo server**: Update health endpoint version from `0.1.1` → `0.3.0`

## Test Plan

- [x] `pnpm build` passes
- [ ] CI tests pass
- [ ] CDN URL `https://cdn.jsdelivr.net/npm/@burnishdev/components/src/tokens.css` returns 200
- [ ] Hosted demo `/api/health` returns version `0.3.0` after deploy