### PR TITLE
perf(demo): enable gzip compression via Hono middleware

### DIFF
--- a/apps/demo/server/index.ts
+++ b/apps/demo/server/index.ts
@@ -11,6 +11,7 @@
  */
 
 import { Hono } from 'hono';
+import { compress } from 'hono/compress';
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { resolve, dirname } from 'node:path';
@@ -23,6 +24,9 @@ import { McpHub, isWriteTool, safePath } from '@burnishdev/server';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = new Hono();
+
+// --- Compression (gzip/deflate) ---
+app.use(compress());
 
 const mcpHub = new McpHub();
 


### PR DESCRIPTION
## Summary

Closes #442

## Changes

Add Hono's built-in `compress()` middleware to the demo server, applied globally before all routes. This compresses HTML, JS, CSS, and JSON responses using gzip/deflate.

- Uses Node.js 20's native `CompressionStream` — no new npm dependencies
- Automatically respects `Accept-Encoding` headers
- Skips small responses (< 1KB default threshold)
- Skips already-encoded or non-compressible content types

Typical JS/CSS/HTML responses compress 60-80%, reducing page load time for HN visitors on the hosted demo.

[skip-screenshot]

## Test Plan

- [x] `pnpm build` passes
- [ ] CI tests pass
- [ ] Deploy to Fly and verify `Content-Encoding: gzip` in response headers