### PR TITLE
fix(renderer): JSON view long strings overflow pre block horizontally

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -915,7 +915,7 @@ body {
 .burnish-json-view {
     background: var(--burnish-surface-alt, #F8F5F5); padding: 16px; border-radius: 4px;
     font-size: 11px; font-family: var(--burnish-font-mono, 'SF Mono', monospace);
-    overflow: auto; max-height: 500px; white-space: pre-wrap; word-break: break-all;
+    overflow: auto; max-height: 500px; white-space: pre-wrap; word-break: break-word;
     border: 1px solid var(--burnish-border-light, #F0EAEA);
 }
 .burnish-markdown-content {


### PR DESCRIPTION
## Summary
Fixes #457

## Root Cause
The `.burnish-json-view` CSS rule used `word-break: break-all`, which breaks long strings at any character — including mid-word — at the container edge. This produces ugly, hard-to-read line breaks in JSON view when description fields contain long sentences.

## Fix
Changed `word-break: break-all` to `word-break: break-word` in the `.burnish-json-view` CSS rule. The existing `white-space: pre-wrap` was already correct. With `break-word`, the browser prefers breaking at word boundaries and only breaks mid-word if a single word exceeds the container width.

**File changed:** `apps/demo/public/style.css` (line 918)

## Verification
Verified with Playwright screenshots — long description strings now wrap at word boundaries instead of breaking mid-character. Both light and dark themes render correctly with no overflow or layout regressions.

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification confirms wrapping at word boundaries in both themes

[skip-screenshot]