### PR TITLE
fix(breadcrumb): collapse descendants on crumb click for back-navigation

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -898,9 +898,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (nodeId) {
             const session = getActiveSession();
             if (session) {
+                // Collapse all descendant nodes so the user visually "goes back"
+                const descendantIds = getDescendantIds(session, nodeId);
+                for (const dId of descendantIds) {
+                    if (dId === nodeId) continue;
+                    const dNode = getNodeById(session, dId);
+                    if (dNode && !dNode.collapsed) {
+                        dNode.collapsed = true;
+                        const el = document.querySelector(`.burnish-node[data-node-id="${dId}"]`);
+                        if (el) el.dataset.collapsed = 'true';
+                    }
+                }
                 session.activeNodeId = nodeId;
                 scrollToNode(nodeId, true);
                 updateBreadcrumb();
+                saveState();
             }
         } else if (crumb.dataset.scrollTop === 'true') {
             const mainContent = document.getElementById('main-content');


### PR DESCRIPTION
## Summary
Fixes #455

## Root Cause
The breadcrumb click handler in `apps/demo/public/app.js` already handled clicks on `.burnish-crumb` elements with `data-node-id` — it set `session.activeNodeId` and called `scrollToNode()`. However, it did not collapse the descendant nodes of the clicked breadcrumb level. This meant clicking a breadcrumb crumb scrolled the page but left all deeper drill-down content expanded, so the user could not visually "go back" to an earlier navigation level.

## Fix
When a non-active breadcrumb crumb is clicked, the handler now:
1. Retrieves all descendant node IDs of the clicked node using `getDescendantIds()`
2. Collapses each descendant by setting `node.collapsed = true` and updating the DOM `data-collapsed` attribute
3. Sets the active node, scrolls to it, updates the breadcrumb, and persists state

This gives users proper back-navigation: clicking a breadcrumb collapses everything below that level, visually returning to the earlier drill-down state.

## Verification
Verified both light and dark mode screenshots — the landing page renders correctly in both themes with no visual regressions. The fix is a behavioral change (JavaScript click handler logic) that activates during drill-down navigation.

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Visual verification: breadcrumb crumb clicks collapse descendant nodes and scroll to the target level

[skip-screenshot]