### PR TITLE
fix(demo): differentiate suggestion buttons by server name

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -852,8 +852,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (btn.dataset.action === 'list-servers') {
             const cachedServers = getCachedServers();
             if (cachedServers && cachedServers.length > 0) {
-                const first = cachedServers[0];
-                renderDeterministicToolListing(first.name, first.tools);
+                const targetName = btn.dataset.server;
+                const target = targetName
+                    ? cachedServers.find(s => s.name === targetName)
+                    : cachedServers[0];
+                if (target) {
+                    renderDeterministicToolListing(target.name, target.tools);
+                }
             }
             return;
         }
@@ -1507,8 +1512,20 @@ async function loadDynamicSuggestions(container) {
         if (starterSection && servers.length > 0) {
             const starters = [];
             for (const s of servers) {
-                const serverPrompts = STARTER_PROMPTS[s.name] || STARTER_PROMPTS._default;
-                starters.push(...serverPrompts.slice(0, 2));
+                // Skip servers with no tools
+                if (!s.tools || s.tools.length === 0) continue;
+                const serverPrompts = STARTER_PROMPTS[s.name];
+                if (serverPrompts) {
+                    starters.push(...serverPrompts.slice(0, 2));
+                } else {
+                    // Generate a labeled default prompt including the server name
+                    const displayName = s.name.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+                    starters.push({
+                        label: `${displayName} tools`,
+                        action: 'list-servers',
+                        server: s.name,
+                    });
+                }
             }
             const limited = starters.slice(0, 6);
             if (limited.length > 0) {
@@ -1522,8 +1539,9 @@ async function loadDynamicSuggestions(container) {
                     }
                     const promptAttr = s.prompt ? ` data-prompt="${escapeAttr(s.prompt)}"` : '';
                     const actionAttr = s.action ? ` data-action="${escapeAttr(s.action)}"` : '';
+                    const serverAttr = s.server ? ` data-server="${escapeAttr(s.server)}"` : '';
                     return `
-                        <button class="burnish-suggestion"${promptAttr}${toolAttr}${argsAttr}${actionAttr} data-label="${escapeAttr(s.label)}">
+                        <button class="burnish-suggestion"${promptAttr}${toolAttr}${argsAttr}${actionAttr}${serverAttr} data-label="${escapeAttr(s.label)}">
                             ${escapeHtml(s.label)}
                         </button>
                     `;


### PR DESCRIPTION
## Summary
Fixes #456

The landing page showed identical "Available tools" suggestion buttons for every MCP server that lacked curated starter prompts. Users could not tell which server each button targeted.

## Root Cause
The `STARTER_PROMPTS._default` array contained a single `{ label: 'Available tools', action: 'list-servers' }` entry. For each server without curated prompts, this same entry was pushed into the starters array, producing duplicate buttons with the same label. The click handler always opened the first server regardless of which button was clicked.

## Fix
- Generate per-server labels for default prompts using the server name (e.g., "Showcase tools", "Sample Files tools")
- Add `data-server` attribute to each button so the click handler opens the correct server's tool listing
- Skip servers with 0 tools so empty servers like `demo-database` do not produce buttons

## Verification
**Light mode:**
![verify-456-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-456-light.png)
**Dark mode:**
![verify-456-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-456-dark.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [x] Visual verification confirms buttons now show server name ("Showcase tools") instead of generic "Available tools"