### PR TITLE
fix(demo): pin CDN deps to exact versions, fix DOMPurify SRI hash

### DIFF
--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -41,17 +41,17 @@
     </script>
 
     <!-- Chart.js for burnish-chart -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
             integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
             crossorigin="anonymous"></script>
 
     <!-- DOMPurify for HTML sanitization -->
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"
-            integrity="sha384-pcBjnGbkyKeOXaoFkmJiuR9E08/6gkmus6/Strimnxtl3uk0Hx23v345pWyC/MMr"
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js"
+            integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7"
             crossorigin="anonymous"></script>
 
     <!-- Marked.js for markdown rendering -->
-    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"
+    <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"
             integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi"
             crossorigin="anonymous"></script>
 


### PR DESCRIPTION
## Summary
Fixes #461

The DOMPurify SRI integrity hash no longer matched the CDN-served file, causing browsers to block the script. This made `window.DOMPurify` undefined, silently breaking all tool execution — nodes appear but with empty content.

## Root Cause
`dompurify@3` is a floating semver tag that resolved to 3.4.0, but the SRI hash was computed against an older version. The same risk existed for chart.js@4 and marked@12.

## Fix
- Pin DOMPurify to `3.4.0` and update SRI hash
- Pin Chart.js to `4.5.1` (hash already correct, pinning prevents future breakage)
- Pin Marked to `12.0.2` (hash already correct, pinning prevents future breakage)

[skip-screenshot]

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Demo functional after deploy (tool execution works)