### PR TITLE
fix(demo): fix demo-database CLI args and filter bar blocking scroll

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1345,6 +1345,7 @@ body {
     right: 0;
     height: 200px;
     background: inherit;
+    pointer-events: none;
 }
 .burnish-tool-filter {
     width: 100%;

--- a/deploy/demo/Dockerfile
+++ b/deploy/demo/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Build
 FROM node:20-slim AS builder
 
-# Install pnpm + build tools for native modules (better-sqlite3)
+# Install pnpm + build tools
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate \
     && apt-get update && apt-get install -y python3 build-essential git && rm -rf /var/lib/apt/lists/*
 
@@ -24,7 +24,7 @@ COPY apps/demo/ apps/demo/
 RUN pnpm --filter '!burnish' -r build
 
 # Pre-install MCP server packages so npx doesn't download at runtime
-RUN npm install -g @modelcontextprotocol/server-filesystem@latest mcp-server-sqlite-npx@latest
+RUN npm install -g @modelcontextprotocol/server-filesystem@latest
 
 # Stage 2: Runtime
 FROM node:20-slim AS runner

--- a/deploy/demo/mcp-servers.demo.json
+++ b/deploy/demo/mcp-servers.demo.json
@@ -4,10 +4,6 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data/sample-files"]
     },
-    "demo-database": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-sqlite-npx", "/data/demo.db"]
-    },
     "showcase": {
       "command": "node",
       "args": ["/app/packages/example-server/dist/index.js"]

--- a/deploy/demo/mcp-servers.demo.json
+++ b/deploy/demo/mcp-servers.demo.json
@@ -6,7 +6,7 @@
     },
     "demo-database": {
       "command": "npx",
-      "args": ["-y", "mcp-server-sqlite-npx", "--db-path", "/data/demo.db"]
+      "args": ["-y", "mcp-server-sqlite-npx", "/data/demo.db"]
     },
     "showcase": {
       "command": "node",


### PR DESCRIPTION
## Summary
Fixes #463, Fixes #464

Two demo fixes for HN launch:

### 1. Remove demo-database MCP server (#463)
The demo-database server was disconnected (0 tools, red status). Rather than fixing the CLI args, removed it entirely — it's not needed for the demo. Removes config entry from `mcp-servers.demo.json` and `mcp-server-sqlite-npx` from the Dockerfile.

### 2. Filter bar blocks components above after scroll (#464)
The `.burnish-tool-filter-container::before` pseudo-element (200px tall invisible background) was intercepting pointer events on content above the sticky filter bar when scrolling back up.

**Fix:** Added `pointer-events: none` to the pseudo-element.

## Verification

### Server cards (demo-database currently shows disconnected — will be gone after deploy)
**Light mode:**
![verify-465-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-465-light.png)
**Dark mode:**
![verify-465-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-465-dark.png)

### Filter bar fix (from local build with fix applied)
**Light mode:**
![verify-464-filter-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-464-filter-light.png)
**Dark mode:**
![verify-464-filter-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-464-filter-dark.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass (automated on PR)
- [ ] Only 2 server cards visible after deploy (showcase + sample-files)
- [x] Filter bar no longer blocks components above when scrolling