### PR TITLE
fix(a11y): increase button click target sizes

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -73,10 +73,10 @@ document.getElementById('theme-toggle')?.addEventListener('click', () => {
 const persistence = new SessionStore();
 const promptLibrary = new PromptLibrary();
 
-const ICON_FOCUS = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="4,1 1,1 1,4"/><polyline points="12,1 15,1 15,4"/><polyline points="4,15 1,15 1,12"/><polyline points="12,15 15,15 15,12"/></svg>`;
-const ICON_RESTORE = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="1,4 4,4 4,1"/><polyline points="12,1 12,4 15,4"/><polyline points="1,12 4,12 4,15"/><polyline points="12,15 12,12 15,12"/></svg>`;
-const ICON_REFRESH = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 8a7 7 0 0 1 13-3.5M15 8a7 7 0 0 1-13 3.5"/><polyline points="1,1 1,5 5,5"/><polyline points="15,15 15,11 11,11"/></svg>`;
-const ICON_HISTORY = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="7"/><polyline points="8,4 8,8 11,10"/></svg>`;
+const ICON_FOCUS = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="4,1 1,1 1,4"/><polyline points="12,1 15,1 15,4"/><polyline points="4,15 1,15 1,12"/><polyline points="12,15 15,15 15,12"/></svg>`;
+const ICON_RESTORE = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="1,4 4,4 4,1"/><polyline points="12,1 12,4 15,4"/><polyline points="1,12 4,12 4,15"/><polyline points="12,15 12,12 15,12"/></svg>`;
+const ICON_REFRESH = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 8a7 7 0 0 1 13-3.5M15 8a7 7 0 0 1-13 3.5"/><polyline points="1,1 1,5 5,5"/><polyline points="15,15 15,11 11,11"/></svg>`;
+const ICON_HISTORY = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="7"/><polyline points="8,4 8,8 11,10"/></svg>`;
 
 // ── State ──
 let searchQuery = '';
@@ -399,7 +399,7 @@ function createNodeEl(node) {
             <span class="burnish-node-time" data-timestamp="${node.timestamp}">${formatTimeAgo(node.timestamp)}</span>
             ${node._executionMode === 'deterministic' ? `<span class="burnish-exec-badge burnish-exec-badge--direct" title="No LLM — direct tool execution">Direct</span>` : ''}
             ${statsTooltip ? `<button class="burnish-node-info" title="View details">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>
             </button>` : ''}
             <button class="burnish-node-maximize" title="Focus">
                 ${ICON_FOCUS}
@@ -634,7 +634,7 @@ function updateNodeHeader(nodeId) {
             const btn = document.createElement('button');
             btn.className = 'burnish-node-info';
             btn.title = 'View details';
-            btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>';
+            btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="8" y="12" text-anchor="middle" font-size="10" font-weight="600" fill="currentColor">i</text></svg>';
             btn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 toggleDiagnosticPanel(node.id);

--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -405,7 +405,7 @@ function createNodeEl(node) {
                 ${ICON_FOCUS}
             </button>
             <button class="burnish-node-refresh" title="Regenerate">${ICON_REFRESH}</button>
-            <button class="burnish-node-delete" data-delete-node="${node.id}" title="Delete this step"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg></button>
+            <button class="burnish-node-delete" data-delete-node="${node.id}" title="Delete this step"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="2" y1="2" x2="14" y2="14"/><line x1="14" y1="2" x2="2" y2="14"/></svg></button>
         </div>
         <div class="burnish-node-content"></div>
     `;

--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -405,7 +405,7 @@ function createNodeEl(node) {
                 ${ICON_FOCUS}
             </button>
             <button class="burnish-node-refresh" title="Regenerate">${ICON_REFRESH}</button>
-            <button class="burnish-node-delete" data-delete-node="${node.id}" title="Delete this step">\u00d7</button>
+            <button class="burnish-node-delete" data-delete-node="${node.id}" title="Delete this step"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg></button>
         </div>
         <div class="burnish-node-content"></div>
     `;

--- a/apps/demo/public/index.html
+++ b/apps/demo/public/index.html
@@ -104,7 +104,7 @@
     <header class="burnish-header">
         <div class="burnish-header-left">
             <button id="btn-toggle-sessions" class="burnish-header-btn burnish-mobile-only" title="Sessions">
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor">
+                <svg width="20" height="20" viewBox="0 0 18 18" fill="currentColor">
                     <path d="M2 4h14M2 9h14M2 14h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
                 </svg>
             </button>
@@ -114,11 +114,11 @@
         </div>
         <div class="burnish-header-right">
             <button id="theme-toggle" class="burnish-theme-toggle" title="Toggle dark mode" aria-label="Toggle dark mode">
-                <svg class="burnish-theme-icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-                <svg class="burnish-theme-icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="burnish-theme-icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                <svg class="burnish-theme-icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
             </button>
             <button id="btn-perf-toggle" class="burnish-header-btn" title="Tool Performance">
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5">
+                <svg width="20" height="20" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5">
                     <rect x="1" y="10" width="3" height="7" rx="0.5"/>
                     <rect x="5.5" y="6" width="3" height="11" rx="0.5"/>
                     <rect x="10" y="3" width="3" height="14" rx="0.5"/>
@@ -126,7 +126,7 @@
                 </svg>
             </button>
             <button id="btn-dashboard-toggle" class="burnish-header-btn" title="Dashboard mode">
-                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5">
+                <svg width="20" height="20" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5">
                     <rect x="1" y="1" width="7" height="7" rx="1"/>
                     <rect x="10" y="1" width="7" height="7" rx="1"/>
                     <rect x="1" y="10" width="7" height="7" rx="1"/>

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -46,8 +46,9 @@ body {
 .burnish-crumb-sep { margin: 0 2px; opacity: 0.5; }
 .burnish-header-btn {
     background: none; border: none; color: rgba(255,255,255,0.7);
-    cursor: pointer; padding: 6px; border-radius: 4px;
+    cursor: pointer; padding: 8px; border-radius: 4px;
     transition: all var(--burnish-transition-fast);
+    min-width: 36px; min-height: 36px; display: flex; align-items: center; justify-content: center;
 }
 .burnish-header-btn:hover { color: white; background: rgba(255,255,255,0.1); }
 
@@ -85,7 +86,7 @@ body {
 .burnish-session-new-btn {
     background: none; border: 1px solid var(--burnish-border, #E5DDDD);
     color: var(--burnish-text-secondary); cursor: pointer;
-    padding: 4px 8px; border-radius: var(--burnish-radius-sm, 4px);
+    padding: 6px 12px; border-radius: var(--burnish-radius-sm, 4px);
     display: flex; align-items: center;
     transition: all var(--burnish-transition-fast);
 }
@@ -167,7 +168,7 @@ body {
 .burnish-session-delete {
     position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
     background: none; border: none; color: var(--burnish-text-muted);
-    cursor: pointer; font-size: 16px; padding: 2px 6px; border-radius: 3px;
+    cursor: pointer; font-size: 16px; padding: 4px 8px; border-radius: 3px;
     opacity: 0; transition: opacity var(--burnish-transition-fast);
 }
 .burnish-session-item:hover .burnish-session-delete { opacity: 1; }
@@ -748,12 +749,13 @@ body {
     color: var(--burnish-text-muted, #9C8F8F);
     cursor: pointer;
     font-size: 16px;
-    padding: 0 4px;
+    padding: 4px 6px;
     border-radius: 3px;
     opacity: 0;
     transition: opacity var(--burnish-transition-fast);
     flex-shrink: 0;
     line-height: 1;
+    min-width: 28px; min-height: 28px; display: inline-flex; align-items: center; justify-content: center;
 }
 /* Maximize/restore */
 .burnish-node-maximize {
@@ -761,11 +763,12 @@ body {
     border: none;
     color: var(--burnish-text-muted, #9C8F8F);
     cursor: pointer;
-    padding: 0 4px;
+    padding: 4px 6px;
     opacity: 0;
     transition: opacity var(--burnish-transition-fast);
     flex-shrink: 0;
     line-height: 1;
+    min-width: 28px; min-height: 28px; display: inline-flex; align-items: center; justify-content: center;
 }
 .burnish-node-header:hover .burnish-node-maximize { opacity: 1; }
 .burnish-node-maximize:hover { color: var(--burnish-accent, #8B3A3A); }
@@ -807,11 +810,12 @@ body {
     border: none;
     color: var(--burnish-text-muted, #9C8F8F);
     cursor: help;
-    padding: 0 4px;
+    padding: 4px 6px;
     opacity: 0;
     transition: opacity var(--burnish-transition-fast);
     flex-shrink: 0;
     line-height: 1;
+    min-width: 28px; min-height: 28px; display: inline-flex; align-items: center; justify-content: center;
 }
 .burnish-node-header:hover .burnish-node-info { opacity: 1; }
 .burnish-node-info:hover { color: var(--burnish-accent, #8B3A3A); }
@@ -821,11 +825,12 @@ body {
     border: none;
     color: var(--burnish-text-muted, #9C8F8F);
     cursor: pointer;
-    padding: 0 4px;
+    padding: 4px 6px;
     opacity: 0;
     transition: opacity var(--burnish-transition-fast);
     flex-shrink: 0;
     line-height: 1;
+    min-width: 28px; min-height: 28px; display: inline-flex; align-items: center; justify-content: center;
 }
 .burnish-node-header:hover .burnish-node-refresh { opacity: 1; }
 .burnish-node-refresh:hover { color: var(--burnish-accent, #8B3A3A); }
@@ -892,8 +897,8 @@ body {
     display: flex; align-items: center; gap: 4px; padding: 8px 0; margin-bottom: 4px;
 }
 .burnish-view-btn {
-    padding: 4px 12px; border: 1px solid var(--burnish-border, #E5DDDD); border-radius: 4px;
-    background: var(--burnish-surface, #fff); cursor: pointer; font-size: 12px;
+    padding: 6px 14px; border: 1px solid var(--burnish-border, #E5DDDD); border-radius: 4px;
+    background: var(--burnish-surface, #fff); cursor: pointer; font-size: 13px;
     color: var(--burnish-text-secondary, #6B5A5A); transition: all 0.15s ease;
 }
 .burnish-view-btn:hover { border-color: var(--burnish-accent, #8B3A3A); color: var(--burnish-accent, #8B3A3A); }
@@ -1125,11 +1130,11 @@ body {
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 4px 12px;
+    padding: 6px 14px;
     border: none;
     border-radius: 4px;
     background: transparent;
-    font-size: 12px;
+    font-size: 13px;
     cursor: pointer;
     color: var(--burnish-text-secondary, #6B5A5A);
     transition: all 0.15s ease;
@@ -1274,7 +1279,7 @@ body {
     position: absolute;
     top: 8px;
     right: 8px;
-    padding: 4px 10px;
+    padding: 6px 12px;
     font-size: var(--burnish-font-size-xs, 12px);
     border: 1px solid var(--burnish-border, #E5DDDD);
     border-radius: 4px;
@@ -1473,8 +1478,8 @@ details.burnish-schema-prop[open] > summary::before {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     border: none;
     border-radius: 6px;
     background: transparent;

--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -748,7 +748,6 @@ body {
     border: none;
     color: var(--burnish-text-muted, #9C8F8F);
     cursor: pointer;
-    font-size: 16px;
     padding: 4px 6px;
     border-radius: 3px;
     opacity: 0;

--- a/packages/components/src/actions.ts
+++ b/packages/components/src/actions.ts
@@ -24,7 +24,7 @@ export class BurnishActions extends LitElement {
             display: inline-flex;
             align-items: center;
             gap: 6px;
-            padding: 7px 14px;
+            padding: 8px 16px;
             border-radius: 6px;
             font-size: 13px;
             font-weight: 500;

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -36,14 +36,13 @@ export class BurnishCard extends LitElement {
             background: none;
             border: none;
             cursor: pointer;
-            padding: 6px;
+            padding: 4px 6px;
             color: var(--burnish-text-muted, #9C8F8F);
-            display: none; align-items: center; justify-content: center; flex-shrink: 0;
+            display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
             min-width: 28px; min-height: 28px;
             border-radius: 3px; transition: all 0.15s ease;
-            font-size: 13px; line-height: 1;
+            line-height: 1;
         }
-        .card:hover .expand-btn { display: flex; }
         .expand-btn:hover { color: var(--burnish-accent, #8B3A3A); }
         .source-badge {
             margin-left: auto;
@@ -316,7 +315,9 @@ export class BurnishCard extends LitElement {
                     <span class="card-title">${this.title}</span>
                     <span class="card-badge" data-status="${statusColor}">${badgeText}</span>
                     <button class="expand-btn" @click=${this._toggleExpand} title="${this._expanded ? 'Collapse' : 'Expand'}">
-                        ${this._expanded ? '↙' : '↗'}
+                        ${this._expanded
+                            ? html`<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="1,4 4,4 4,1"/><polyline points="12,1 12,4 15,4"/><polyline points="1,12 4,12 4,15"/><polyline points="12,15 12,12 15,12"/></svg>`
+                            : html`<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="4,1 1,1 1,4"/><polyline points="12,1 15,1 15,4"/><polyline points="4,15 1,15 1,12"/><polyline points="12,15 15,15 15,12"/></svg>`}
                     </button>
                 </div>
                 ${this.body ? html`<div class="card-body">${unsafeHTML(this._renderMarkdown(this.body))}</div>` : ''}

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -36,11 +36,12 @@ export class BurnishCard extends LitElement {
             background: none;
             border: none;
             cursor: pointer;
-            padding: 2px;
+            padding: 6px;
             color: var(--burnish-text-muted, #9C8F8F);
-            display: none; align-items: center; flex-shrink: 0;
+            display: none; align-items: center; justify-content: center; flex-shrink: 0;
+            min-width: 28px; min-height: 28px;
             border-radius: 3px; transition: all 0.15s ease;
-            font-size: 10px; line-height: 1;
+            font-size: 13px; line-height: 1;
         }
         .card:hover .expand-btn { display: flex; }
         .expand-btn:hover { color: var(--burnish-accent, #8B3A3A); }
@@ -156,7 +157,7 @@ export class BurnishCard extends LitElement {
         .meta-value { color: var(--burnish-text); font-weight: 500; }
         .card-action {
             padding: var(--burnish-space-sm, 8px) var(--burnish-space-lg, 16px);
-            font-size: var(--burnish-font-size-sm, 12px); color: var(--burnish-link, #7C3030);
+            font-size: var(--burnish-font-size-sm, 13px); color: var(--burnish-link, #7C3030);
             opacity: 0.6; transition: opacity var(--burnish-transition-fast);
             cursor: pointer;
             overflow: hidden;
@@ -177,8 +178,8 @@ export class BurnishCard extends LitElement {
         }
         .link-btn {
             display: inline-flex; align-items: center; gap: 4px;
-            padding: 2px 8px; border: 1px solid var(--burnish-border, #E5DDDD);
-            border-radius: 3px; font-size: 11px; text-decoration: none;
+            padding: 4px 10px; border: 1px solid var(--burnish-border, #E5DDDD);
+            border-radius: 4px; font-size: 12px; text-decoration: none;
             color: var(--burnish-link, #7C3030); background: none;
             cursor: pointer; transition: all 0.15s ease;
         }
@@ -186,7 +187,7 @@ export class BurnishCard extends LitElement {
             background: rgba(139, 58, 58, 0.06);
             border-color: var(--burnish-link, #7C3030);
         }
-        .link-icon { font-size: 10px; }
+        .link-icon { font-size: 12px; }
         .card-footer {
             display: flex;
             align-items: center;

--- a/packages/components/src/form.ts
+++ b/packages/components/src/form.ts
@@ -72,11 +72,11 @@ export class BurnishForm extends LitElement {
         .form-input-row { display: flex; gap: 4px; }
         .form-input-row .form-input { flex: 1; }
         .form-lookup-btn {
-            padding: 0 10px; border: 1px solid var(--burnish-border, #E5DDDD); border-radius: 6px;
+            padding: 6px 12px; border: 1px solid var(--burnish-border, #E5DDDD); border-radius: 6px;
             background: var(--burnish-surface-alt, #F3EDED); cursor: pointer;
             color: var(--burnish-text-muted, #6B5A5A); font-size: 14px;
             display: flex; align-items: center; transition: all 0.15s ease;
-            flex-shrink: 0;
+            flex-shrink: 0; min-height: 32px;
         }
         .form-lookup-btn:hover {
             background: var(--burnish-border-light, #F0EAEA);

--- a/packages/components/src/table.ts
+++ b/packages/components/src/table.ts
@@ -46,7 +46,7 @@ export class BurnishTable extends LitElement {
             cursor: pointer; user-select: none; white-space: nowrap;
         }
         th:hover { color: var(--burnish-text, #2D1F1F); }
-        th .sort-arrow { font-size: 10px; margin-left: 4px; opacity: 0.4; }
+        th .sort-arrow { font-size: 12px; margin-left: 4px; opacity: 0.4; }
         th .sort-arrow.active { opacity: 1; color: var(--burnish-accent, #8B3A3A); }
         th:last-child { cursor: default; }
         td {
@@ -74,14 +74,14 @@ export class BurnishTable extends LitElement {
         }
         .table-pagination { display: flex; align-items: center; gap: 6px; }
         .page-btn {
-            padding: 3px 8px; border: 1px solid var(--burnish-border, #E5DDDD);
-            border-radius: 3px; background: var(--burnish-surface, #fff); color: var(--burnish-text, #2D1F1F); cursor: pointer; font-size: 12px;
+            padding: 6px 10px; border: 1px solid var(--burnish-border, #E5DDDD);
+            border-radius: 4px; background: var(--burnish-surface, #fff); color: var(--burnish-text, #2D1F1F); cursor: pointer; font-size: 13px;
         }
         .page-btn:hover:not(:disabled) { background: var(--burnish-surface-alt, #F8F5F5); }
         .page-btn:disabled { opacity: 0.3; cursor: not-allowed; }
         .page-size-select {
-            padding: 2px 4px; border: 1px solid var(--burnish-border, #E5DDDD);
-            border-radius: 3px; font-size: 11px; background: var(--burnish-input-bg, var(--burnish-surface, #fff)); color: var(--burnish-text, #2D1F1F);
+            padding: 4px 6px; border: 1px solid var(--burnish-border, #E5DDDD);
+            border-radius: 4px; font-size: 12px; background: var(--burnish-input-bg, var(--burnish-surface, #fff)); color: var(--burnish-text, #2D1F1F);
         }
         .no-results {
             padding: 24px 16px; text-align: center;

--- a/tests/launch-polish.spec.ts
+++ b/tests/launch-polish.spec.ts
@@ -24,14 +24,14 @@ test.describe('launch polish (#414, #415)', () => {
 
         await page.goto('/');
 
-        const serverBtns = page.locator('#server-buttons button');
+        const exploreBtns = page.locator('#server-buttons .card-action');
         try {
-            await serverBtns.first().waitFor({ state: 'visible', timeout: 30_000 });
+            await exploreBtns.first().waitFor({ state: 'visible', timeout: 30_000 });
         } catch {
             test.skip(true, 'MCP servers not connected in time');
             return;
         }
-        await serverBtns.first().click();
+        await exploreBtns.first().click();
         await page.waitForSelector('.burnish-node', { timeout: 10_000 });
 
         const before = await page.locator('.burnish-node').count();

--- a/tests/no-tools-overview.spec.ts
+++ b/tests/no-tools-overview.spec.ts
@@ -3,22 +3,21 @@ import { test, expect } from '@playwright/test';
 test('server button generates tool listing without LLM', async ({ page }) => {
     await page.goto('/');
 
-    // Wait for server buttons — skip test if MCP servers didn't connect
-    const serverBtns = page.locator('#server-buttons button');
+    // Wait for server cards — skip test if MCP servers didn't connect
+    const exploreBtns = page.locator('#server-buttons .card-action');
     try {
-        await serverBtns.first().waitFor({ state: 'visible', timeout: 30_000 });
+        await exploreBtns.first().waitFor({ state: 'visible', timeout: 30_000 });
     } catch {
         test.skip(true, 'MCP servers not connected in time');
         return;
     }
 
-    // Click a server button (prefer filesystem — fewer tools, faster)
-    const fsButton = page.locator('.burnish-suggestion-server', { hasText: 'filesystem' });
-    if (await fsButton.count() > 0) {
-        await fsButton.click();
+    // Click "Explore →" on a server card (prefer filesystem — fewer tools, faster)
+    const fsCard = page.locator('#server-buttons burnish-card[title="filesystem"]');
+    if (await fsCard.count() > 0) {
+        await fsCard.locator('.card-action').click();
     } else {
-        // Click whatever server button exists
-        await page.locator('.burnish-suggestion-server').first().click();
+        await exploreBtns.first().click();
     }
 
     // Wait for a node to appear

--- a/tests/persistence.spec.ts
+++ b/tests/persistence.spec.ts
@@ -26,15 +26,15 @@ test('session with explorer steps persists after refresh', async ({ page }) => {
     await page.goto('/');
     await page.waitForSelector('.burnish-session-item');
 
-    // Wait for server buttons — skip test if MCP servers didn't connect
-    const serverBtns = page.locator('#server-buttons button');
+    // Wait for server cards — skip test if MCP servers didn't connect
+    const exploreBtns = page.locator('#server-buttons .card-action');
     try {
-        await serverBtns.first().waitFor({ state: 'visible', timeout: 30_000 });
+        await exploreBtns.first().waitFor({ state: 'visible', timeout: 30_000 });
     } catch {
         test.skip(true, 'MCP servers not connected in time');
         return;
     }
-    await page.locator('.burnish-suggestion-server').first().click();
+    await exploreBtns.first().click();
 
     // Wait for tool listing to render
     await page.waitForSelector('burnish-card', { timeout: 10_000 });


### PR DESCRIPTION
## Summary
Fixes #471

Increases click target sizes across all interactive buttons to meet WCAG 2.2 Level AA minimum (24x24px).

## Changes
- Increased icon SVG dimensions (14→16px for tool icons, 12→14px for history, 16→18px for theme icons, 18→20px for header icons)
- Node delete button: replaced text × with 16x16 SVG X icon matching other action icons
- Card expand button: replaced text arrows (↗/↙) with 16x16 SVG focus/restore icons, always visible
- Added min-width/min-height constraints (36px header, 28px node actions) with flexbox centering
- Increased padding on all button classes across demo app and component packages
- Bumped font-size from 12→13px on view and mode buttons

## Verification

**Header buttons (light / dark):**
![verify-471-header-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-header-light.png)
![verify-471-header-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-header-dark.png)

**Session sidebar — new session button (light / dark):**
![verify-471-session-header-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-session-header-light.png)
![verify-471-session-header-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-session-header-dark.png)

**Card expand button (light / dark):**
![verify-471-card-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-card-light.png)
![verify-471-card-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-card-dark.png)

**Node action buttons — info, focus, refresh, delete (light / dark):**
![verify-471-node-actions-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-node-actions-light.png)
![verify-471-node-actions-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-node-actions-dark.png)

**View switcher — Cards / Table / JSON (light / dark):**
![verify-471-view-switcher-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-view-switcher-light.png)
![verify-471-view-switcher-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-view-switcher-dark.png)

**Table with pagination + sort arrows (light / dark):**
![verify-471-table-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-table-light.png)
![verify-471-table-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-table-dark.png)

**Copy button in JSON view (light / dark):**
![verify-471-copy-btn-light](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-copy-btn-light.png)
![verify-471-copy-btn-dark](https://raw.githubusercontent.com/danfking/burnish/screenshots/verify-471-copy-btn-dark.png)

## Test Plan
- [x] `pnpm build` passes
- [ ] CI tests pass
- [x] Visual verification screenshots for every changed button area in both themes