### PR TITLE
fix(style): add gap between disclosure triangle and text in schema tree

### DIFF
--- a/apps/demo/public/style.css
+++ b/apps/demo/public/style.css
@@ -1374,11 +1374,12 @@ body {
     list-style: none;
 }
 .burnish-schema-tree-wrapper > summary::before {
-    content: '\25BC ';
+    content: '\25BC';
     font-size: 10px;
+    margin-right: 8px;
 }
 .burnish-schema-tree-wrapper:not([open]) > summary::before {
-    content: '\25B6 ';
+    content: '\25B6';
 }
 .burnish-schema-tree {
     font-family: var(--burnish-font-mono, monospace);
@@ -1465,11 +1466,12 @@ details.burnish-schema-prop > summary {
     list-style: none;
 }
 details.burnish-schema-prop > summary::before {
-    content: '\25B6 ';
+    content: '\25B6';
     font-size: 10px;
+    margin-right: 8px;
 }
 details.burnish-schema-prop[open] > summary::before {
-    content: '\25BC ';
+    content: '\25BC';
 }
 
 /* ── Theme Toggle ── */


### PR DESCRIPTION
## Summary
Fixes #484

## Root Cause
`apps/demo/public/style.css` used `content: '\25BC '` on the schema tree's `::before` pseudo-element — relying on a trailing space character, which rendered as a hair-thin gap between the disclosure triangle and the property name.

## Fix
Drop the trailing space and use `margin-right: 8px` on the `::before` instead. Also applied to nested `details.burnish-schema-prop` triangles.

## Verification
**Before:** ▼list-tasks object — triangle hugs the text
**After:** ▼ list-tasks object — clear gap

[skip-screenshot]