### PR TITLE
chore(fly): warm 2 machines for launch week

### DIFF
--- a/deploy/demo/fly.toml
+++ b/deploy/demo/fly.toml
@@ -14,7 +14,7 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 2
 
   [http_service.concurrency]
     type = "requests"


### PR DESCRIPTION
## Summary
Fixes #487

Bump `min_machines_running` from 1 → 2 in `deploy/demo/fly.toml` so the Tue 2026-04-21 Show HN + Wed PH traffic spikes don't hit cold-start on the second machine.

## Rationale
- `auto_stop_machines = "stop"` fully stops idle machines (5-10s resume)
- With min=1, only first machine is warm; second cold-starts under load
- HN traffic arrives in spikes; cold-start during peak = failed requests

## Cost
~\$2/month extra for one additional always-on shared-cpu-1x machine. Will revert after launch week.

[skip-screenshot]