### PR TITLE
fix(example-server): trim showcase tile description to fit card

### DIFF
--- a/packages/example-server/src/index.ts
+++ b/packages/example-server/src/index.ts
@@ -26,7 +26,7 @@ const server = new McpServer(
   },
   {
     instructions:
-      "A deep-graph demo MCP server for the Burnish Explorer. A fictional consulting company with projects, clients, team members, tasks, comments, incidents, and orders — all interconnected, so you can click from a project into a task into a comment into the comment's author and keep going. Showcases Burnish's drill-down navigation, auto-generated forms, and rich result rendering.",
+      "A fictional consulting company with projects, clients, tasks, and orders. Everything is interconnected, so you can click from a project into a task into a comment and keep exploring.",
   }
 );
 


### PR DESCRIPTION
## Summary
Fixes #489

## Root Cause
The showcase server's `instructions` text was long enough to overflow the 3-line clamp in the server tile card, running into the "Explore →" footer link on the landing page.

## Fix
Trimmed the description from 340 characters to 160 characters while preserving the key information: what the data is (fictional consulting company) and what makes it interesting (interconnected entities you can drill into).

**Before:** "A deep-graph demo MCP server for the Burnish Explorer. A fictional consulting company with projects, clients, team members, tasks, comments, incidents, and orders — all interconnected, so you can click from a project into a task into a comment into the comment's author and keep going. Showcases Burnish's drill-down navigation, auto-generated forms, and rich result rendering."

**After:** "A fictional consulting company with projects, clients, tasks, and orders. Everything is interconnected, so you can click from a project into a task into a comment and keep exploring."

## Test Plan
- [ ] `pnpm build` passes
- [ ] Description fits within card tile on landing page