### PR TITLE
fix(components): prevent card-body from stretching in flex layout

### DIFF
--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -135,6 +135,7 @@ export class BurnishCard extends LitElement {
             -webkit-line-clamp: 3;
             -webkit-box-orient: vertical;
             overflow: hidden;
+            flex: 0 0 auto;
         }
         .card-body h1, .card-body h2, .card-body h3, .card-body h4 {
             font-size: 13px; font-weight: 600; margin: 8px 0 4px; color: var(--burnish-text, #2D1F1F);


### PR DESCRIPTION
## Summary
Fixes #489 (together with #490)

## Root Cause
The `.card` uses `display:flex; flex-direction:column; height:100%`. When two cards sit side-by-side and one is taller, the shorter card stretches to match. The `.card-body` div grew to fill that extra space, pushing its content past the `-webkit-line-clamp: 3` visual boundary and into the "Explore →" footer.

## Fix
Added `flex: 0 0 auto` to `.card-body` so it stays at its clamped intrinsic height regardless of the flex container's size.

[skip-screenshot]

## Test Plan
- [x] `pnpm build` passes
- [ ] Description text no longer overflows into footer at narrow viewports