### PR TITLE
fix(components,demo): cap card-body height and skip required-arg shortcuts

### DIFF
--- a/apps/demo/public/app.js
+++ b/apps/demo/public/app.js
@@ -1545,7 +1545,7 @@ async function loadDynamicSuggestions(container) {
 
                 const schema = tool.inputSchema;
                 const hasRequired = schema?.required?.length > 0;
-                const hasParams = schema?.properties && Object.keys(schema.properties).length > 0;
+                if (hasRequired) continue;
 
                 shortcuts.push({
                     label,

--- a/packages/components/src/card.ts
+++ b/packages/components/src/card.ts
@@ -135,7 +135,7 @@ export class BurnishCard extends LitElement {
             -webkit-line-clamp: 3;
             -webkit-box-orient: vertical;
             overflow: hidden;
-            flex: 0 0 auto;
+            max-height: calc(3 * 1.5em + 2px);
         }
         .card-body h1, .card-body h2, .card-body h3, .card-body h4 {
             font-size: 13px; font-weight: 600; margin: 8px 0 4px; color: var(--burnish-text, #2D1F1F);

--- a/packages/example-server/src/index.ts
+++ b/packages/example-server/src/index.ts
@@ -26,7 +26,7 @@ const server = new McpServer(
   },
   {
     instructions:
-      "A fictional consulting company with projects, clients, tasks, and orders. Everything is interconnected, so you can click from a project into a task into a comment and keep exploring.",
+      "A fictional consulting company with interconnected projects, clients, tasks, and orders you can click through and explore.",
   }
 );
 


### PR DESCRIPTION
## Summary
Fixes #489

## Root Cause
Two issues on the landing page:

1. The card body used `-webkit-line-clamp: 3` but in a flex column layout the clamped height wasn't enforced, causing description text to overflow into the "Explore" footer.
2. Shortcut buttons included tools with required parameters (e.g. `get-project`), which error on click since no arguments are provided.

## Fix
- Added `max-height: calc(3 * 1.5em + 2px)` to `.card-body` to hard-cap the height with room for descenders
- Shortened showcase server description to fit comfortably in 2-3 lines
- Shortcut generation now skips tools where `schema.required.length > 0`

[skip-screenshot]

## Test Plan
- [x] `pnpm build` passes
- [x] Local demo verified at 1280x800 and 1024x768: description fits, no clipping, footer separated
- [x] Shortcut buttons only show zero-argument tools